### PR TITLE
Remove upper pin from Tomli

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ exclude =
 
 [options.extras_require]
 all =
-    tomli>=1.2.1,<2
+    tomli>=1.2.1
     packaging>=20.4
     trove-classifiers>=2021.10.20
 


### PR DESCRIPTION
It seems the code is compatible with `tomli==2.0.0`