### PR TITLE
Fix entry-points format to allow values without the `:obj.attr` part

### DIFF
--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -182,8 +182,6 @@ def python_entrypoint_name(value: str) -> bool:
 
 
 def python_entrypoint_reference(value: str) -> bool:
-    if ":" not in value:
-        return False
     module, _, rest = value.partition(":")
     if "[" in rest:
         obj, _, extras_ = rest.partition("[")
@@ -196,5 +194,6 @@ def python_entrypoint_reference(value: str) -> bool:
     else:
         obj = rest
 
-    identifiers = chain(module.split("."), obj.split("."))
+    module_parts = module.split(".")
+    identifiers = chain(module_parts, obj.split(".")) if rest else module_parts
     return all(python_identifier(i.strip()) for i in identifiers)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -72,6 +72,11 @@ ENTRYPOINT_EXAMPLES = {
             "calver-by-date": "setuptools_scm.version:calver_by_date",
         },
     },
+    "anyio": {
+        "pytest11": {
+            "anyio": "anyio.pytest_plugin",
+        },
+    },
 }
 
 


### PR DESCRIPTION
According to the standard entry-points can be either in the form `importable.module`, or `importable.module:object.attr`, but currently `validate-pyproject` requires the second part.