### PR TITLE
Improve trove classifier validation

### DIFF
--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -1,8 +1,8 @@
 import logging
 import re
 import string
-from itertools import chain
-from urllib.parse import urlparse
+import typing
+from itertools import chain as _chain
 
 _logger = logging.getLogger(__name__)
 
@@ -101,7 +101,7 @@ def pep508_versionspec(value: str) -> bool:
 
 def pep517_backend_reference(value: str) -> bool:
     module, _, obj = value.partition(":")
-    identifiers = (i.strip() for i in chain(module.split("."), obj.split(".")))
+    identifiers = (i.strip() for i in _chain(module.split("."), obj.split(".")))
     return all(python_identifier(i) for i in identifiers if i)
 
 
@@ -136,6 +136,8 @@ except ImportError:  # pragma: no cover
 
 
 def url(value: str) -> bool:
+    from urllib.parse import urlparse
+
     try:
         parts = urlparse(value)
         return bool(parts.scheme and parts.netloc)
@@ -195,5 +197,5 @@ def python_entrypoint_reference(value: str) -> bool:
         obj = rest
 
     module_parts = module.split(".")
-    identifiers = chain(module_parts, obj.split(".")) if rest else module_parts
+    identifiers = _chain(module_parts, obj.split(".")) if rest else module_parts
     return all(python_identifier(i.strip()) for i in identifiers)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -277,6 +277,7 @@ class TestClassifiers:
 
     If at any point these tests start to fail, we know that we need to change strategy.
     """
+
     VALID_CLASSIFIERS = (
         "Development Status :: 5 - Production/Stable",
         "Framework :: Django",


### PR DESCRIPTION
Currently when embedded `validate-pyproject` will require users to add `trove-classifiers` to their dependencies. In some scenarios (e.g. `setuptools`) that may be very annoying (see comment in https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821/21).

A possible alternative is to download the classifiers directly from PyPI if the package is not installed, this is done by both [`distutils`](https://github.com/pypa/setuptools/blob/6193a69d8608b6ca7e0e5ac1223d63abb55eee3b/setuptools/_distutils/command/register.py#L85) and [`flit`](https://github.com/pypa/flit/blob/bdafdfec7158ba3774a47f7ed3d03645854a0540/flit/validate.py#L52).

This change adds the download as a fallback mechanism, but also skip this validation if the `NO_NETWORK` environment variable is used or if the download fails.