### PR TITLE
Improve URL validation when scheme prefix is not present

### DIFF
--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -191,8 +191,6 @@ def url(value: str) -> bool:
             )
             if not (value.startswith("/") or value.startswith("\\") or "@" in value):
                 parts = urlparse(f"http://{value}")
-        elif not parts.netloc:
-            return False
 
         return bool(parts.scheme and parts.netloc)
     except Exception:

--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -183,8 +183,18 @@ def url(value: str) -> bool:
 
     try:
         parts = urlparse(value)
+        if not parts.scheme:
+            _logger.warning(
+                "For maximum compatibility please make sure to include a "
+                "`scheme` prefix in your URL (e.g. 'http://'). "
+                f"Given value: {value}"
+            )
+            if not (value.startswith("/") or value.startswith("\\") or "@" in value):
+                parts = urlparse(f"http://{value}")
+        elif not parts.netloc:
+            return False
+
         return bool(parts.scheme and parts.netloc)
-        # ^  TODO: should we enforce schema to be http(s)?
     except Exception:
         return False
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -234,7 +234,6 @@ def test_valid_url(example):
         "",
         42,
         "p@python.org",
-        "python.org",
         "http:python.org",
         "/python.org",
     ],


### PR DESCRIPTION
Motivation:

> `setuptools._vendor._validate_pyproject.fastjsonschema_exceptions.JsonSchemaValueException`: data.urls.homepage must be url - my URL field did not start with ‘https://’, but [the example in PEP 621](https://www.python.org/dev/peps/pep-0621/#example) suggested this should work
>
> *originally posted in in (https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821)*