### PR TITLE
Use Python 3.10 in Cirrus CI for typecheck

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,6 +32,7 @@ env:
     # This script is also used in Windows, so the shell is not POSIX
     - git config --global user.email "you@example.com"
     - git config --global user.name "Your Name"
+    - python -VV  # Useful for debugging
   clean_workspace_script:
     # Avoid information carried from one run to the other
     - rm -rf .coverage junit-*.xml .tox

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,7 +32,6 @@ env:
     # This script is also used in Windows, so the shell is not POSIX
     - git config --global user.email "you@example.com"
     - git config --global user.name "Your Name"
-    - python -VV  # Useful for debugging
   clean_workspace_script:
     # Avoid information carried from one run to the other
     - rm -rf .coverage junit-*.xml .tox

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -61,7 +61,7 @@ typecheck_task:
   name: typecheck (Linux - 3.10)
   only_if: $TYPE_CHECKING == 'true'
   clone_script: *clone
-  container: {image: "python:3.9-bullseye"}  # most recent => better type support
+  container: {image: "python:3.10-bullseye"}  # most recent => better type support
   pip_cache: *pip-cache
   mypy_cache:
     folder: .mypy_cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,9 @@ jobs:
       - uses: actions/checkout@v2
         with: {fetch-depth: 0}  # deep clone for setuptools-scm
       - uses: actions/setup-python@v2
-        with: {python-version: "3.9"}  # Temporarily downgrade to Python 3.9, see #22
+        with: {python-version: "3.10"}
       - name: Run static analysis and format checkers
-        run: |
-          python -VV
-          pipx run tox -e lint,typecheck
+        run: pipx run tox -e lint,typecheck
       - name: Build package distribution files
         run: pipx run tox -e clean,build
       - name: Record the path of wheel distribution

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,11 @@ jobs:
       - uses: actions/checkout@v2
         with: {fetch-depth: 0}  # deep clone for setuptools-scm
       - uses: actions/setup-python@v2
-        with: {python-version: "3.10"}
+        with: {python-version: "3.9"}  # Temporarily downgrade to Python 3.9, see #22
       - name: Run static analysis and format checkers
-        run: pipx run tox -e lint,typecheck
+        run: |
+          python -VV
+          pipx run tox -e lint,typecheck
       - name: Build package distribution files
         run: pipx run tox -e clean,build
       - name: Record the path of wheel distribution

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,10 @@ testing =
     pytest
     pytest-cov
 
+typecheck =
+    mypy
+    importlib-resources
+
 [options.entry_points]
 # Add here console scripts like:
 console_scripts =

--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 try:  # pragma: no cover
-    if sys.version_info[:2] < (3, 7) or TYPE_CHECKING:
+    if sys.version_info[:2] < (3, 7) or TYPE_CHECKING:  # See #22
         from importlib_resources import files
     else:
         from importlib.resources import files

--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 try:  # pragma: no cover
-    if sys.version_info[:2] < (3, 7):
+    if sys.version_info[:2] < (3, 7) or TYPE_CHECKING:
         from importlib_resources import files
     else:
         from importlib.resources import files

--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -39,7 +39,7 @@ try:  # pragma: no cover
     if sys.version_info[:2] < (3, 7):
         from importlib_resources import files
     else:
-        from importlib.resources import files  # type: ignore[attr-defined]
+        from importlib.resources import files
 
     def read_text(package: Union[str, ModuleType], resource) -> str:
         return files(package).joinpath(resource).read_text(encoding="utf-8")

--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,7 @@ passenv =
     # ^ ensure colors
 extras =
     all
-deps =
-    mypy
+    typecheck
 commands =
     python -m mypy {posargs:src}
 


### PR DESCRIPTION
For some reason the `typechecker` is failing in the GitHub action for Python 3.10, but not in the Cirrus CI.

Specifically the error is:
```
src/validate_pyproject/api.py:42: error: Module "importlib.resources" has no
attribute "files"  [attr-defined]
            from importlib.resources import files
            ^
Found 1 error in 1 file (checked 24 source files)
```

The GHA environment is:
``
CPython (3.10.2)
mypy==0.931,
mypy-extensions==0.4.3,
packaging==21.3,
pyparsing==3.0.7,
tomli==2.0.1,
trove-classifiers==2022.2.16,
typing_extensions==4.1.1
```

The Cirrus CI environment is:
```
mypy==0.931,
mypy-extensions==0.4.3,
packaging==21.3,
pyparsing==3.0.7,
tomli==2.0.1,
trove-classifiers==2022.2.16,
typing_extensions==4.1.1,
```

Maybe the best solution here is to downgrade one of CirrusCI or GHA to use Python 3.9 to run the typechecker...