### PR TITLE
Avoid polluting `ValidationError` traceback with printing generate code 

### DIFF
--- a/src/validate_pyproject/error_reporting.py
+++ b/src/validate_pyproject/error_reporting.py
@@ -1,6 +1,7 @@
 import io
 import json
 import logging
+import os
 import re
 from contextlib import contextmanager
 from textwrap import indent, wrap
@@ -61,7 +62,8 @@ class ValidationError(JsonSchemaValueException):
     def _from_jsonschema(cls, ex: JsonSchemaValueException):
         formatter = _ErrorFormatting(ex)
         obj = cls(str(formatter), ex.value, formatter.name, ex.definition, ex.rule)
-        obj.__cause__, obj.__traceback__ = ex.__cause__, ex.__traceback__
+        if os.getenv("JSONSCHEMA_DEBUG_CODE_GENERATION", "false").lower() != "false":
+            obj.__cause__, obj.__traceback__ = ex.__cause__, ex.__traceback__
         obj._original_message = ex.message
         obj.summary = formatter.summary
         obj.details = formatter.details

--- a/src/validate_pyproject/error_reporting.py
+++ b/src/validate_pyproject/error_reporting.py
@@ -62,7 +62,8 @@ class ValidationError(JsonSchemaValueException):
     def _from_jsonschema(cls, ex: JsonSchemaValueException):
         formatter = _ErrorFormatting(ex)
         obj = cls(str(formatter), ex.value, formatter.name, ex.definition, ex.rule)
-        if os.getenv("JSONSCHEMA_DEBUG_CODE_GENERATION", "false").lower() != "false":
+        debug_code = os.getenv("JSONSCHEMA_DEBUG_CODE_GENERATION", "false").lower()
+        if debug_code != "false":  # pragma: no cover
             obj.__cause__, obj.__traceback__ = ex.__cause__, ex.__traceback__
         obj._original_message = ex.message
         obj.summary = formatter.summary

--- a/src/validate_pyproject/extra_validations.py
+++ b/src/validate_pyproject/extra_validations.py
@@ -24,7 +24,7 @@ def validate_project_dynamic(pyproject: T) -> T:
 
     for field in dynamic:
         if field in project_table:
-            msg = f"You cannot provided a value for `project.{field}` and "
+            msg = f"You cannot provide a value for `project.{field}` and "
             msg += "list it under `project.dynamic` at the same time"
             name = f"data.project.{field}"
             value = {field: project_table[field], "...": " # ...", "dynamic": dynamic}

--- a/tests/invalid-examples/pdm/redefining-as-dynamic/errors.txt
+++ b/tests/invalid-examples/pdm/redefining-as-dynamic/errors.txt
@@ -1,1 +1,1 @@
-You cannot provided a value for `project.classifiers` and list it under `project.dynamic` at the same time
+You cannot provide a value for `project.classifiers` and list it under `project.dynamic` at the same time


### PR DESCRIPTION
Only set traceback in validation error if explicitly set in env var