### PR TITLE
Remove `license` and `license-files` from `dynamic` in `setuptools` plugin.

### DIFF
--- a/src/validate_pyproject/plugins/setuptools.schema.json
+++ b/src/validate_pyproject/plugins/setuptools.schema.json
@@ -172,9 +172,20 @@
           "^.*$": {"type": "string", "format": "python-qualified-identifier"}
       }
     },
+    "license-files": {
+      "type": "array",
+      "items": {"type": "string"},
+      "$$description": [
+        "PROVISIONAL: List of glob patterns for all license files being distributed.",
+        "(might become standard with PEP 639)."
+      ],
+      "default": ["LICEN[CS]E*", " COPYING*", " NOTICE*", "AUTHORS*"],
+      "$comment": "TODO: revise if PEP 639 is accepted. Probably ``project.license-files``?"
+    },
     "dynamic": {
       "type": "object",
       "description": "Instructions for loading :pep:`621`-related metadata dynamically",
+      "additionalProperties": false,
       "properties": {
         "version": {
           "$$description": [
@@ -195,24 +206,6 @@
             {"properties": {"content-type": {"type": "string"}}}
           ],
           "required": ["file"]
-        },
-        "license": {
-          "type": "string",
-          "$$description": [
-            "PROVISIONAL: A string specifying the license of the package",
-            "(might change with PEP 639)"
-          ],
-          "$comment": "TODO: revise if PEP 639 is accepted. Maybe ``license-expression``?"
-        },
-        "license-files": {
-          "type": "array",
-          "items": {"type": "string"},
-          "$$description": [
-            "PROVISIONAL: List of glob patterns for all license files being distributed.",
-            "(might change with PEP 639)"
-          ],
-          "default": ["LICEN[CS]E*", " COPYING*", " NOTICE*", "AUTHORS*"],
-          "$comment": "TODO: revise if PEP 639 is accepted. Maybe ``license-files.glob``?"
         }
       }
     }

--- a/tests/examples/pretend-setuptools/04-pyproject.toml
+++ b/tests/examples/pretend-setuptools/04-pyproject.toml
@@ -4,6 +4,7 @@ readme = "README.md"
 dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = ["numpy>=1.18.5"]
+license.file = "LICENSE.txt"
 
 [project.entry-points]
 pandas_plotting_backends = {matplotlib = "project.plotting:matplotlib_plot"}

--- a/tests/examples/pretend-setuptools/07-pyproject.toml
+++ b/tests/examples/pretend-setuptools/07-pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "myproj"
 keywords = ["some", "key", "words"]
+license = {text = "MIT"}
 dynamic = [
     "version",
     "description",
@@ -37,6 +38,7 @@ build-backend = "setuptools.build_meta"
 package-dir = {"" = "src"}
 zip-safe = true
 platforms = ["any"]
+license-files = ["LICENSE*", "NOTICE*"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -46,8 +48,6 @@ namespaces = true
 sdist = "pkg.mod.CustomSdist"
 
 [tool.setuptools.dynamic]
-license = "MIT"
-license-files = ["LICENSE*", "NOTICE*"]
 version = {attr = "pkg.__version__.VERSION"}
 description = {file = ["README.md"]}
 readme = {file = ["README.md"], content-type = "text/markdown"}

--- a/tests/invalid-examples/pretend-setuptools/pep621/license/empty.errors.txt
+++ b/tests/invalid-examples/pretend-setuptools/pep621/license/empty.errors.txt
@@ -1,0 +1,1 @@
+`project.license` must be valid exactly by one definition (0 matches found)

--- a/tests/invalid-examples/pretend-setuptools/pep621/license/empty.toml
+++ b/tests/invalid-examples/pretend-setuptools/pep621/license/empty.toml
@@ -1,0 +1,26 @@
+[project]
+name = "some-project"
+author = { name = "Anderson Bravalheri" }
+description = "Some description"
+readme = "README.rst"
+license = {}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Topic :: Utilities",
+]
+dynamic = ["version"]
+requires-python = ">=3.6"
+dependencies = [
+    "importlib-metadata; python_version<\"3.8\"",
+    "appdirs>=1.4.4,<2",
+]
+
+[tool.setuptools]
+zip-safe = false
+include-package-data = true
+exclude-package-data = { "pkg1" = ["*.yaml"] }
+package-dir = {"" = "src"} # all the packages under the src folder
+platforms = ["any"]
+
+[tool.setuptools.packages]
+find = { where = ["src"], exclude = ["tests"], namespaces = true }


### PR DESCRIPTION
Place license-file in tool.setuptools instead of dynamic

Now that we clarified that PEP 621 does not specify anything about the (non-standard) core metadata field `License-file` and that it is not necessary to add `license` to `dynamic` to be able to automatically fill it, there is no motivation for keeping this field in `tool.setuptools.dynamic` instead of `tool.setuptools` (directly).

See:
- https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821/49
- https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821/57

As such there is also little motivation to allow `license` and `license-files` in `dynamic`...
There is nothing else setuptools can do outside of what the standard already allows.
Even with PEP 639 (the draft currently establishes that the backend can backfill `license-files` without needing an explicit `dynamic` if it is not provided).