### PR TITLE
Ensure `version` is given either statically or dynamically

### DIFF
--- a/src/validate_pyproject/project_metadata.schema.json
+++ b/src/validate_pyproject/project_metadata.schema.json
@@ -250,8 +250,13 @@
   "additionalProperties": false,
   "if": {
     "not": {
-      "required": ["version"],
-      "$$description": ["version is statically defined in the ``version`` field"]
+      "required": ["dynamic"],
+      "properties": {
+        "dynamic": {
+          "contains": {"const": "version"},
+          "$$description": ["version is listed in ``dynamic``"]
+        }
+      }
     },
     "$$comment": [
       "According to :pep:`621`:",
@@ -266,12 +271,8 @@
     ]
   },
   "then": {
-    "properties": {
-      "dynamic": {
-        "contains": {"const": "version"},
-        "$$description": ["version should be listed in ``dynamic``"]
-      }
-    }
+    "required": ["version"],
+    "$$description": ["version should be statically defined in the ``version`` field"]
   },
 
   "definitions": {

--- a/tests/examples/simple/dynamic-version.toml
+++ b/tests/examples/simple/dynamic-version.toml
@@ -1,0 +1,3 @@
+[project]
+name = "spam"
+dynamic = ["version"]

--- a/tests/examples/simple/minimal.toml
+++ b/tests/examples/simple/minimal.toml
@@ -1,0 +1,3 @@
+[project]
+name = "spam"
+version = "2020.0.0"

--- a/tests/invalid-examples/pep621/missing-fields/missing-version-with-dynamic.errors.txt
+++ b/tests/invalid-examples/pep621/missing-fields/missing-version-with-dynamic.errors.txt
@@ -1,0 +1,1 @@
+`project` must contain ['version'] properties

--- a/tests/invalid-examples/pep621/missing-fields/missing-version-with-dynamic.toml
+++ b/tests/invalid-examples/pep621/missing-fields/missing-version-with-dynamic.toml
@@ -1,0 +1,3 @@
+[project]
+name = "proj"
+dynamic = []

--- a/tests/invalid-examples/pep621/missing-fields/missing-version.errors.txt
+++ b/tests/invalid-examples/pep621/missing-fields/missing-version.errors.txt
@@ -1,0 +1,1 @@
+`project` must contain ['version'] properties

--- a/tests/invalid-examples/pep621/missing-fields/missing-version.toml
+++ b/tests/invalid-examples/pep621/missing-fields/missing-version.toml
@@ -1,0 +1,2 @@
+[project]
+name = "proj"


### PR DESCRIPTION
Closes #28.