### PR TITLE
Fix pre-commit hook when called with multiple files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,14 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear]
+
+
+- repo: local  # self-test for `validate-pyproject` hook
+  hooks:
+  - id: validate-pyproject
+    name: Validate pyproject.toml
+    language: python
+    files: ^tests/examples/pretend-setuptools/07-pyproject.toml$
+    entry: validate-pyproject
+    additional_dependencies:
+      - validate-pyproject[all]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Validation library for a simple check on pyproject.toml,
     including optional dependencies
   language: python
-  files: pyproject.toml
+  files: ^pyproject.toml$
   entry: validate-pyproject
   additional_dependencies:
     - .[all]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,18 @@
 Changelog
 =========
 
+Version 0.8
+===========
+
+- New :pypi:`pre-commit` hook, #40
+- Allow multiple TOML files to be validated at once via **CLI**
+  (*no changes regarding the Python API*).
+
 Version 0.7.2
 =============
 
 - ``setuptools`` plugin:
-    - Allow ``dependencies``/``optional-dependencies`` to use file directives (#37)
+    - Allow ``dependencies``/``optional-dependencies`` to use file directives, #37
 
 Version 0.7.1
 =============

--- a/README.rst
+++ b/README.rst
@@ -152,8 +152,8 @@ pre-commit
 
 By default, this ``pre-commit`` hook will only validate the ``pyproject.toml``
 file at the root of the project repository.
-You can customize that by defining a `custom regular expression pattern`_ for
-``files``, but please have in mind that only one file can be analysed per hook.
+You can customize that by defining a `custom regular expression pattern`_ using
+the ``files`` parameter.
 
 
 Note

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,12 @@ pre-commit
         hooks:
           - id: validate-pyproject
 
+By default, this ``pre-commit`` hook will only validate the ``pyproject.toml``
+file at the root of the project repository.
+You can customize that by defining a `custom regular expression pattern`_ for
+``files``, but please have in mind that only one file can be analysed per hook.
+
+
 Note
 ====
 
@@ -164,6 +170,7 @@ For details and usage information on PyScaffold see https://pyscaffold.org/.
 
 
 .. _contribution guides: https://validate-pyproject.readthedocs.io/en/latest/contributing.html
+.. _custom regular expression pattern: https://pre-commit.com/#regular-expressions
 .. _our docs: https://validate-pyproject.readthedocs.io
 .. _ini2toml: https://ini2toml.readthedocs.io
 .. _JSON Schema: https://json-schema.org/

--- a/src/validate_pyproject/cli.py
+++ b/src/validate_pyproject/cli.py
@@ -196,7 +196,7 @@ def run(args: Sequence[str] = ()):
     if params.dump_json:
         print(json.dumps(toml_equivalent, indent=2))
     else:
-        print("Valid file")
+        print(f"Valid {_format_file(params.input_file)}")
     return 0
 
 
@@ -226,3 +226,9 @@ def _format_plugin_help(plugin: PluginWrapper) -> str:
     help_text = plugin.help_text
     help_text = f": {_flatten_str(help_text)}" if help_text else ""
     return f'* "{plugin.tool}"{help_text}'
+
+
+def _format_file(file: io.TextIOBase) -> str:
+    if hasattr(file, "name") and file.name:  # type: ignore[attr-defined]
+        return f"file: {file.name}"  # type: ignore[attr-defined]
+    return "file"

--- a/src/validate_pyproject/extra_validations.py
+++ b/src/validate_pyproject/extra_validations.py
@@ -5,12 +5,12 @@ JSON Schema library).
 
 from typing import Mapping, TypeVar
 
-from ._vendor.fastjsonschema import JsonSchemaValueException
+from .error_reporting import ValidationError
 
 T = TypeVar("T", bound=Mapping)
 
 
-class RedefiningStaticFieldAsDynamic(JsonSchemaValueException):
+class RedefiningStaticFieldAsDynamic(ValidationError):
     """According to PEP 621:
 
     Build back-ends MUST raise an error if the metadata specifies a field

--- a/src/validate_pyproject/pre_compile/cli.py
+++ b/src/validate_pyproject/pre_compile/cli.py
@@ -83,7 +83,7 @@ def run(args: Sequence[str] = ()):
     return 0
 
 
-main = cli.exceptisons2exit()(run)
+main = cli.exceptions2exit()(run)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The hook added by #40 seems to be called with all the files that match the file name `pyproject.toml`. However the CLI tool is only able to handle 1 file at time.

This change tries to fix that by allowing the CLI to validate multiple files.

Additionally, since this is the most common use case, the `files` regular expression is changed to only match `pyproject.toml` in the project root.

@wwuck, please let me know if you have any objections here.