### PR TITLE
Fix example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ You can also use ``validate-pyproject`` in your Python scripts or projects:
     pyproject_as_dict = loads(pyproject_toml_str)
 
     # now we can use validate-pyproject
-    validator = Validator()
+    validator = api.Validator()
 
     try:
         validator(pyproject_as_dict)


### PR DESCRIPTION
`Validator()` is under `validate_pyproject.api`.