### PR TITLE
Link directly to PEPs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,9 +175,9 @@ For details and usage information on PyScaffold see https://pyscaffold.org/.
 .. _ini2toml: https://ini2toml.readthedocs.io
 .. _JSON Schema: https://json-schema.org/
 .. _library dependency: https://setuptools.pypa.io/en/latest/userguide/dependency_management.html
-.. _PEP 517: https://www.python.org/dev/peps/pep-0517/
-.. _PEP 518: https://www.python.org/dev/peps/pep-0518/
-.. _PEP 621: https://www.python.org/dev/peps/pep-0621/
+.. _PEP 517: https://peps.python.org/pep-0517/
+.. _PEP 518: https://peps.python.org/pep-0518/
+.. _PEP 621: https://peps.python.org/pep-0621/
 .. _pipx: https://pypa.github.io/pipx/
 .. _project: https://packaging.python.org/tutorials/managing-dependencies/
 .. _setuptools: https://setuptools.pypa.io/en/stable/

--- a/src/validate_pyproject/project_metadata.schema.json
+++ b/src/validate_pyproject/project_metadata.schema.json
@@ -31,7 +31,7 @@
     "readme": {
       "$$description": [
         "`Full/detailed description of the project in the form of a README",
-        "<https://www.python.org/dev/peps/pep-0621/#readme>`_",
+        "<https://peps.python.org/pep-0621/#readme>`_",
         "with meaning similar to the one defined in `core metadata's Description",
         "<https://packaging.python.org/specifications/core-metadata/#description>`_"
       ],
@@ -101,7 +101,7 @@
     },
     "license": {
       "description":
-        "`Project license <https://www.python.org/dev/peps/pep-0621/#license>`_.",
+        "`Project license <https://peps.python.org/pep-0621/#license>`_.",
       "oneOf": [
         {
           "properties": {
@@ -279,7 +279,7 @@
     "author": {
       "$id": "#/definitions/author",
       "title": "Author or Maintainer",
-      "$comment": "https://www.python.org/dev/peps/pep-0621/#authors-maintainers",
+      "$comment": "https://peps.python.org/pep-0621/#authors-maintainers",
       "type": "object",
       "properties": {
         "name": {

--- a/tests/examples/atoml/pyproject.toml
+++ b/tests/examples/atoml/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "pdm.pep517.api"
 
 [project]
 # PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+# See https://peps.python.org/pep-0621/
 name = "atoml"
 # version = {use_scm = true}  ->  invalid, must be string
 authors = [

--- a/tests/examples/pdm/pyproject.toml
+++ b/tests/examples/pdm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 # PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+# See https://peps.python.org/pep-0621/
 authors = [
     {name = "frostming", email = "mianghong@gmail.com"},
 ]

--- a/tests/invalid-examples/pdm/invalid-version/pyproject.toml
+++ b/tests/invalid-examples/pdm/invalid-version/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 # PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+# See https://peps.python.org/pep-0621/
 authors = [
     {name = "frostming", email = "mianghong@gmail.com"},
 ]

--- a/tests/invalid-examples/pdm/redefining-as-dynamic/pyproject.toml
+++ b/tests/invalid-examples/pdm/redefining-as-dynamic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 # PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+# See https://peps.python.org/pep-0621/
 authors = [
     {name = "frostming", email = "mianghong@gmail.com"},
 ]


### PR DESCRIPTION
Link directly to PEPs at their new home at https://peps.python.org/ rather than going via redirect at the old https://www.python.org/dev/peps/

(Split out from https://github.com/pypa/setuptools/pull/3770.)