### PR TITLE
Allow PEP 561 stubs in `tool.setuptools.package-dir`

### DIFF
--- a/src/validate_pyproject/plugins/setuptools.schema.json
+++ b/src/validate_pyproject/plugins/setuptools.schema.json
@@ -74,13 +74,7 @@
         {
           "title": "Array of Python package identifiers",
           "type": "array",
-          "items": {
-            "type": "string",
-            "anyOf": [
-              {"format": "python-module-name"},
-              {"format": "pep561-stub-name"}
-            ]
-          }
+          "items": {"$ref": "#/definitions/package-name"}
         },
         {"$ref": "#/definitions/find-directive"}
       ]
@@ -95,7 +89,7 @@
       "type": "object",
       "additionalProperties": false,
       "propertyNames": {
-        "oneOf": [{"format": "python-module-name"}, {"const": ""}]
+        "oneOf": [{"const": ""}, {"$ref": "#/definitions/package-name"}]
       },
       "patternProperties": {
         "^.*$": {"type": "string" }
@@ -225,6 +219,16 @@
   },
 
   "definitions": {
+    "package-name": {
+      "$id": "#/definitions/package-name",
+      "title": "Valid package name",
+      "description": "Valid package name (importable or PEP 561).",
+      "type": "string",
+      "anyOf": [
+        {"format": "python-module-name"},
+        {"format": "pep561-stub-name"}
+      ]
+    },
     "file-directive": {
       "$id": "#/definitions/file-directive",
       "title": "'file:' directive",

--- a/tests/examples/setuptools/09-pyproject.toml
+++ b/tests/examples/setuptools/09-pyproject.toml
@@ -1,0 +1,14 @@
+# Setuptools should allow stub-only package names in `package-dir` (PEP 561)
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mypkg-stubs"
+version = "0.0.0"
+
+[tool.setuptools]
+packages = ["otherpkg-stubs", "namespace.mod.stubs"]
+
+[tool.setuptools.package-dir]
+otherpkg-stubs = "namespace/mod/stubs"

--- a/tests/invalid-examples/setuptools/package-dir/invalid-stub.errors.txt
+++ b/tests/invalid-examples/setuptools/package-dir/invalid-stub.errors.txt
@@ -1,0 +1,4 @@
+exactly one of the following:
+{predefined value: ''}
+{format: 'python-module-name'}
+{format: 'pep561-stub-name'}

--- a/tests/invalid-examples/setuptools/package-dir/invalid-stub.toml
+++ b/tests/invalid-examples/setuptools/package-dir/invalid-stub.toml
@@ -1,0 +1,6 @@
+[project]
+name = "project"
+version = "0.42"
+
+[tool.setuptools]
+package-dir = {"package-st42ubs" = "src"}


### PR DESCRIPTION
Complement to #86. 