### PR TITLE
Improve validation of `attr` directives for setuptools

### DIFF
--- a/src/validate_pyproject/plugins/setuptools.schema.json
+++ b/src/validate_pyproject/plugins/setuptools.schema.json
@@ -256,7 +256,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "attr": {"type": "string"}
+        "attr": {"format": "python-qualified-identifier"}
       },
       "required": ["attr"]
     },

--- a/tests/invalid-examples/setuptools/attr/missing-attr-name.errors.txt
+++ b/tests/invalid-examples/setuptools/attr/missing-attr-name.errors.txt
@@ -1,0 +1,2 @@
+`tool.setuptools.dynamic.version` must be valid exactly by one definition
+'attr': {format: 'python-qualified-identifier'}

--- a/tests/invalid-examples/setuptools/attr/missing-attr-name.toml
+++ b/tests/invalid-examples/setuptools/attr/missing-attr-name.toml
@@ -1,0 +1,17 @@
+# Issue pypa/setuptools#3928
+# https://github.com/RonnyPfannschmidt/reproduce-setuptools-dynamic-attr
+[build-system]
+build-backend = "_own_version_helper"
+backend-path = ["."]
+requires = ["setuptools" ]
+
+[project]
+name = "ronnypfannschmidt.setuptools-build-attr-error-reproduce"
+description = "reproducer for a setuptools issue"
+requires-python = ">=3.7"
+dynamic = [
+  "version",
+]
+
+[tool.setuptools.dynamic]
+version = { attr = "_own_version_helper."}


### PR DESCRIPTION
This change is motivated by the issue in pypa/setuptools#3928.