### PR TITLE
fix: plugin wrapper repr not helpful

### DIFF
--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -47,6 +47,9 @@ class PluginWrapper:
             return ""
         return Template(tpl).safe_substitute(tool=self.tool, id=self.id)
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.tool!r}, {self._load_fn!r})"
+
 
 def iterate_entry_points(group=ENTRYPOINT_GROUP) -> Iterable[EntryPoint]:
     """Produces a generator yielding an EntryPoint object for each plugin registered

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -48,7 +48,7 @@ class PluginWrapper:
         return Template(tpl).safe_substitute(tool=self.tool, id=self.id)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.tool!r}, {self._load_fn!r})"
+        return f"{self.__class__.__name__}({self.tool!r}, {self.id})"
 
 
 def iterate_entry_points(group=ENTRYPOINT_GROUP) -> Iterable[EntryPoint]:


### PR DESCRIPTION
I was seeing

```
>       assert len(params.plugins) == 1
E       AssertionError: assert 2 == 1
E        +  where 2 = len([<validate_pyproject.plugins.PluginWrapper object at 0x1107e85d0>, <validate_pyproject.plugins.PluginWrapper object at 0x10fe8e810>])
E        +    where [<validate_pyproject.plugins.PluginWrapper object at 0x1107e85d0>, <validate_pyproject.plugins.PluginWrapper object at 0x10fe8e810>] = CliParams(input_file=[<_io.TextIOWrapper name='/private/var/folders/_8/xtbws09n017fbzdx9dmgnyyr0000gn/T/pytest-of-henryschreiner/pytest-7/test_parse_setuptools_distutil1/pyproject.toml' mode='r' encoding='UTF-8'>], plugins=[<validate_pyproject.plugins.PluginWrapper object at 0x1107e85d0>, <validate_pyproject.plugins.PluginWrapper object at 0x10fe8e810>], loglevel=30, dump_json=False).plugins
```


In the pytest failures messages. This instead produces a much more helpful:

```
>       assert len(params.plugins) == 1
E       AssertionError: assert 2 == 1
E        +  where 2 = len([PluginWrapper('distutils', load_builtin_plugin), PluginWrapper('scikit-build', get_skbuild_schema)])
E        +    where [PluginWrapper('distutils', load_builtin_plugin), PluginWrapper('scikit-build', get_skbuild_schema)] = CliParams(input_file=[<_io.TextIOWrapper name='/private/var/folders/_8/xtbws09n017fbzdx9dmgnyyr0000gn/T/pytest-of-henryschreiner/pytest-9/test_parse_setuptools_distutil1/pyproject.toml' mode='r' encoding='UTF-8'>], plugins=[PluginWrapper('distutils', load_builtin_plugin), PluginWrapper('scikit-build', get_skbuild_schema)], loglevel=30, dump_json=False).plugins
```

Which makes the problem clear (I can't have a plugin installed into the testing environment).
