### PR TITLE
fix: setuptools readme field fix

### DIFF
--- a/src/validate_pyproject/plugins/setuptools.schema.json
+++ b/src/validate_pyproject/plugins/setuptools.schema.json
@@ -229,7 +229,13 @@
           "type": "object",
           "anyOf": [
             {"$ref": "#/definitions/file-directive"},
-            {"type": "object", "properties": {"content-type": {"type": "string"}}}
+            {
+              "type": "object",
+              "properties": {
+                "content-type": {"type": "string"},
+                "file": { "$ref": "#/definitions/file-directive/properties/file" }
+              },
+              "additionalProperties": false}
           ],
           "required": ["file"]
         }

--- a/src/validate_pyproject/plugins/setuptools.schema.json
+++ b/src/validate_pyproject/plugins/setuptools.schema.json
@@ -226,9 +226,10 @@
           }
         },
         "readme": {
+          "type": "object",
           "anyOf": [
             {"$ref": "#/definitions/file-directive"},
-            {"properties": {"content-type": {"type": "string"}}}
+            {"type": "object", "properties": {"content-type": {"type": "string"}}}
           ],
           "required": ["file"]
         }

--- a/tests/examples/setuptools/readme-pyproject.toml
+++ b/tests/examples/setuptools/readme-pyproject.toml
@@ -1,0 +1,2 @@
+[tool.setuptools]
+dynamic.readme = { "file" = ["README.md"] }

--- a/tests/invalid-examples/setuptools/dynamic/readme-missing-file.errors.txt
+++ b/tests/invalid-examples/setuptools/dynamic/readme-missing-file.errors.txt
@@ -1,0 +1,1 @@
+`tool.setuptools.dynamic.readme` must contain ['file'] properties

--- a/tests/invalid-examples/setuptools/dynamic/readme-missing-file.toml
+++ b/tests/invalid-examples/setuptools/dynamic/readme-missing-file.toml
@@ -1,0 +1,2 @@
+[tool.setuptools.dynamic.readme]
+content-type = "text/plain"

--- a/tests/invalid-examples/setuptools/dynamic/readme-too-many.errors.txt
+++ b/tests/invalid-examples/setuptools/dynamic/readme-too-many.errors.txt
@@ -1,0 +1,1 @@
+`tool.setuptools.dynamic.readme` cannot be validated by any definition

--- a/tests/invalid-examples/setuptools/dynamic/readme-too-many.toml
+++ b/tests/invalid-examples/setuptools/dynamic/readme-too-many.toml
@@ -1,0 +1,4 @@
+[tool.setuptools.dynamic.readme]
+file = ["README.md"]
+content-type = "text/plain"
+something-else = "not supposed to be here"


### PR DESCRIPTION
Forgot I found this small bug. It was possible to sneak extra keys in `tool.setuptools.dynamic.readme`.