### PR TITLE
chore: move a couple of configs to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,17 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 # See configuration details in https://github.com/pypa/setuptools_scm
 version_scheme = "no-guess-dev"
+
+[tool.mypy]
+pretty = true
+show_error_codes = true
+show_error_context = true
+show_traceback = true
+ignore_missing_imports = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+[tool.pytest.ini_options]
+addopts = ["--cov", "validate_pyproject", "--cov-report", "term-missing", "--verbose"]
+norecursedirs = ["dist", "build", ".tox"]
+testpaths = ["tests"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,41 +92,11 @@ repo_review.checks =
 repo_review.families =
     validate_pyproject = validate_pyproject.repo_review:repo_review_families
 
-[tool:pytest]
-# Specify command line options as you would do when invoking pytest directly.
-# e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
-# in order to write a coverage file that can be read by Jenkins.
-# CAUTION: --cov flags may prohibit setting breakpoints while debugging.
-#          Comment those flags to avoid this pytest issue.
-addopts =
-    --cov validate_pyproject --cov-report term-missing
-    --verbose
-norecursedirs =
-    dist
-    build
-    .tox
-testpaths = tests
-# Use pytest markers to select/deselect specific tests
-# markers =
-#     slow: mark tests as slow (deselect with '-m "not slow"')
-#     system: mark end-to-end system tests
-
 [devpi:upload]
 # Options for the devpi: PyPI server and packaging tool
 # VCS export must be deactivated since we are using setuptools-scm
 no_vcs = 1
 formats = bdist_wheel
-
-[mypy]
-pretty = True
-show_error_codes = True
-show_error_context = True
-show_traceback = True
-ignore_missing_imports = True
-warn_redundant_casts = True
-warn_unused_ignores = True
-# Add here plugins
-# plugins = mypy_django_plugin.main, returns.contrib.mypy.returns_plugin
 
 [pyscaffold]
 # PyScaffold's parameters when the project was created.


### PR DESCRIPTION
Moving a few things from setup.cfg to pyproject.toml.

Will follow up with mypy updates, but it's much easier to use Mypy's pyproject.toml config than the old ini config.