### PR TITLE
chore: use 2x faster pre-commit mirror for Black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,11 +31,10 @@ repos:
   - id: ruff
     args: [--fix, --show-fixes]
 
-- repo: https://github.com/psf/black
+- repo: https://github.com/psf/black-pre-commit-mirror
   rev: 23.11.0
   hooks:
   - id: black
-    language_version: python3
 
 - repo: https://github.com/asottile/blacken-docs
   rev: 1.16.0


### PR DESCRIPTION
This is faster, since it installs the mypyc compiled wheel of black instead of getting the source.
