### PR TITLE
feat: add fragment support to entrypoints

### DIFF
--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -117,8 +117,8 @@ def load_from_entry_point(entry_point: EntryPoint) -> PluginWrapper:
     """Carefully load the plugin, raising a meaningful message in case of errors"""
     try:
         fn = entry_point.load()
-        name, _, fragment = entry_point.name.partition("#")
-        return PluginWrapper(name, fn, fragment=fragment)
+        fragment = getattr(fn, "fragment", "")
+        return PluginWrapper(entry_point.name, fn, fragment=fragment)
     except Exception as ex:
         raise ErrorLoadingPlugin(entry_point=entry_point) from ex
 

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -84,7 +84,10 @@ class PluginWrapper:
         return Template(tpl).safe_substitute(tool=self.tool, id=self.id)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.tool!r}, {self.id})"
+        args = [repr(self.tool), self.id]
+        if self.fragment:
+            args.append(f"fragment={self.fragment!r}")
+        return f"{self.__class__.__name__}({', '.join(args)})"
 
 
 if typing.TYPE_CHECKING:

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -54,9 +54,10 @@ class PluginProtocol(Protocol):
 
 
 class PluginWrapper:
-    def __init__(self, tool: str, load_fn: Plugin):
+    def __init__(self, tool: str, load_fn: Plugin, *, fragment: str = ""):
         self._tool = tool
         self._load_fn = load_fn
+        self._fragment = fragment
 
     @property
     def id(self) -> str:
@@ -72,7 +73,7 @@ class PluginWrapper:
 
     @property
     def fragment(self) -> str:
-        return ""
+        return self._fragment
 
     @property
     def help_text(self) -> str:
@@ -116,7 +117,8 @@ def load_from_entry_point(entry_point: EntryPoint) -> PluginWrapper:
     """Carefully load the plugin, raising a meaningful message in case of errors"""
     try:
         fn = entry_point.load()
-        return PluginWrapper(entry_point.name, fn)
+        name, _, fragment = entry_point.name.partition("#")
+        return PluginWrapper(name, fn, fragment=fragment)
     except Exception as ex:
         raise ErrorLoadingPlugin(entry_point=entry_point) from ex
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -31,6 +31,16 @@ def test_load_from_entry_point__error():
         plugins.load_from_entry_point(fake)
 
 
+def test_load_from_entry_point_fragment():
+    entry = "validate_pyproject.api:load_builtin_plugin"
+    real = EntryPoint(
+        "cibuildwheel#/properties/tool/properties", entry, ENTRYPOINT_GROUP
+    )
+    p = plugins.load_from_entry_point(real)
+    assert p.fragment == "/properties/tool/properties"
+    assert p.tool == "cibuildwheel"
+
+
 def is_entry_point(ep):
     return all(hasattr(ep, attr) for attr in ("name", "load"))
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,6 +6,7 @@ import sys
 
 import pytest
 
+import validate_pyproject.api
 from validate_pyproject import plugins
 from validate_pyproject.plugins import ENTRYPOINT_GROUP, ErrorLoadingPlugin
 
@@ -31,11 +32,15 @@ def test_load_from_entry_point__error():
         plugins.load_from_entry_point(fake)
 
 
-def test_load_from_entry_point_fragment():
-    entry = "validate_pyproject.api:load_builtin_plugin"
-    real = EntryPoint(
-        "cibuildwheel#/properties/tool/properties", entry, ENTRYPOINT_GROUP
+def test_load_from_entry_point_fragment(monkeypatch):
+    monkeypatch.setattr(
+        validate_pyproject.api.load_builtin_plugin,
+        "fragment",
+        "/properties/tool/properties",
+        raising=False,
     )
+    entry = "validate_pyproject.api:load_builtin_plugin"
+    real = EntryPoint("cibuildwheel", entry, ENTRYPOINT_GROUP)
     p = plugins.load_from_entry_point(real)
     assert p.fragment == "/properties/tool/properties"
     assert p.tool == "cibuildwheel"


### PR DESCRIPTION
This is an experiment in adding fragments to entrypoints. While [it is suggested](https://packaging.python.org/en/latest/specifications/entry-points/#data-model) to use simple chars, these chars are valid according to the spec. This is the simplest way to add support for fragments to entrypoints too.

FYI, this is for `validate-pyproject-schema-store`, which I've got mostly setup, which would use CI to provide static copies of the schemastore files on a regular basis, and can be pinned.