### PR TITLE
chore: use ruff format instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,7 @@ repos:
   hooks:
   - id: ruff
     args: [--fix, --show-fixes]
-
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 23.12.1
-  hooks:
-  - id: black
+  - id: ruff-format
 
 - repo: https://github.com/asottile/blacken-docs
   rev: 1.16.0

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -153,8 +153,8 @@ Implement your changes
 
    Please make sure to see the validation messages from |pre-commit|_ and fix
    any eventual issues.
-   This should automatically use ruff_/black_ to check/fix the code style
-   in a way that is compatible with the project.
+   This should automatically use ruff_ to check/fix the code style in a way
+   that is compatible with the project.
 
    .. important:: Don't forget to add unit tests and documentation in case your
       contribution adds an additional feature and is not just a bugfix.
@@ -275,7 +275,6 @@ on PyPI_, the following steps can be used to release a new version for
 .. |tox| replace:: ``tox``
 
 
-.. _black: https://pypi.org/project/black/
 .. _contribution-guide.org: https://www.contribution-guide.org/
 .. _creating a PR: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
 .. _descriptive commit message: https://chris.beams.io/posts/git-commit

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -102,7 +102,8 @@ def iterate_entry_points(group: str = ENTRYPOINT_GROUP) -> Iterable[EntryPoint]:
         # The select method was introduced in importlib_metadata 3.9 (and Python 3.10)
         # and the previous dict interface was declared deprecated
         select = typing.cast(
-            Any, getattr(entries, "select")  # noqa: B009
+            Any,
+            getattr(entries, "select"),  # noqa: B009
         )  # typecheck gymnastics
         entries_: Iterable[EntryPoint] = select(group=group)
     else:  # pragma: no cover


### PR DESCRIPTION
This moves to using Ruff's black-like formatter instead of a separate tool. Soon, it will also be able to run on md/rst natively too, but for now (it takes some infrastructure changes to support reading in md/rst, it actually already understands them for docstrings), docs are still checked with blacken-docs. Simplifies things a bit and requires one less virtual environment and is faster. (It's not more elegantly integrated with the formatter, at least yet, though, though it does share config)
