### PR TITLE
Return more appropriate URL for [build-system] table

### DIFF
--- a/src/validate_pyproject/pyproject_toml.schema.json
+++ b/src/validate_pyproject/pyproject_toml.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
 
-  "$id": "https://packaging.python.org/en/latest/specifications/dependency-specifiers/",
+  "$id": "https://packaging.python.org/en/latest/specifications/declaring-build-dependencies/",
   "title": "Data structure for ``pyproject.toml`` files",
   "$$description": [
     "File format containing build-time configurations for the Python ecosystem. ",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ def test_load():
     spec = api.load("pyproject_toml")
     assert isinstance(spec, Mapping)
 
-    assert spec["$id"] == f"{PYPA_SPECS}/dependency-specifiers/"
+    assert spec["$id"] == f"{PYPA_SPECS}/declaring-build-dependencies/"
 
     spec = api.load("project_metadata")
     assert spec["$id"] == f"{PYPA_SPECS}/pyproject-toml/"


### PR DESCRIPTION
Now that https://packaging.python.org/en/latest/specifications/declaring-build-dependencies/ is working again, I think it is good to use it as reference, due to its significance.

See https://github.com/abravalheri/validate-pyproject/pull/147/files#r1465469332.

OBS: This reverts a previous change.