### PR TITLE
Remove invalid top-of-the-file `# type: ignore` statement

### DIFF
--- a/src/validate_pyproject/pre_compile/__init__.py
+++ b/src/validate_pyproject/pre_compile/__init__.py
@@ -112,7 +112,6 @@ def load_licenses() -> Dict[str, str]:
 
 NOCHECK_HEADERS = (
     "# noqa",
-    "# type: ignore",
     "# ruff: noqa",
     "# flake8: noqa",
     "# pylint: skip-file",


### PR DESCRIPTION
On mypy for PyPy, this causes a `[syntax]` error: https://github.com/pypa/setuptools/actions/runs/8040607909/job/21958905599?pr=4192#step:9:1517 **even if the file is excluded** (because it is imported)

On regular mypy this causes `error: Module "validate_pyproject.fastjsonschema_validations" has no attribute "validate"  [attr-defined]` (in setuptools, the exact error was: `error: Module "setuptools.config._validate_pyproject.fastjsonschema_validations" has no attribute "validate"  [attr-defined]`