### PR TITLE
Improve API docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,7 +77,7 @@ Code Contributions
 ==================
 
 Understanding how the project works
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 
 If you have a change in mind, please have a look in our :doc:`dev-guide`.
 It explains the main aspects of the project and provide a brief overview on how

--- a/docs/_gendocs.py
+++ b/docs/_gendocs.py
@@ -1,0 +1,40 @@
+"""``sphinx-apidoc`` only allows users to specify "exclude patterns" but not
+"include patterns". This module solves that gap.
+"""
+
+import shutil
+from pathlib import Path
+
+MODULE_TEMPLATE = """
+``{name}``
+~~{underline}~~
+
+.. automodule:: {name}
+   :members:{_members}
+   :undoc-members:
+   :show-inheritance:
+"""
+
+__location__ = Path(__file__).parent
+
+
+def gen_stubs(module_dir: str, output_dir: str):
+    shutil.rmtree(output_dir, ignore_errors=True)  # Always start fresh
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    manifest = shutil.copy(__location__ / "modules.rst.in", out / "modules.rst")
+    for module in iter_public(manifest):
+        text = module_template(module)
+        Path(output_dir, f"{module}.rst").write_text(text, encoding="utf-8")
+
+
+def iter_public(manifest):
+    toc = Path(manifest).read_text(encoding="utf-8")
+    lines = (x.strip() for x in toc.splitlines())
+    return (x for x in lines if x.startswith("validate_pyproject."))
+
+
+def module_template(name: str, *members: str) -> str:
+    underline = "~" * len(name)
+    _members = (" " + ", ".join(members)) if members else ""
+    return MODULE_TEMPLATE.format(name=name, underline=underline, _members=_members)

--- a/docs/_gendocs.py
+++ b/docs/_gendocs.py
@@ -13,6 +13,7 @@ MODULE_TEMPLATE = """
    :members:{_members}
    :undoc-members:
    :show-inheritance:
+   :special-members: __call__
 """
 
 __location__ = Path(__file__).parent

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -292,6 +292,7 @@ intersphinx_mapping = {
     "setuptools": ("https://setuptools.pypa.io/en/stable/", None),
     "pyscaffold": ("https://pyscaffold.org/en/stable", None),
     "fastjsonschema": ("https://horejsek.github.io/python-fastjsonschema/", None),
+    "pypa": ("https://packaging.python.org/en/latest/", None),
 }
 extlinks = {
     "issue": (f"{repository}/issues/%s", "issue #%s"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,52 +8,20 @@
 # serve to show the default.
 
 import os
-import shutil
 import sys
 
 # -- Path setup --------------------------------------------------------------
 
 __location__ = os.path.dirname(__file__)
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.insert(0, __location__)
 sys.path.insert(0, os.path.join(__location__, "../src"))
 
-# -- Run sphinx-apidoc -------------------------------------------------------
-# This hack is necessary since RTD does not issue `sphinx-apidoc` before running
-# `sphinx-build -b html . _build/html`. See Issue:
-# https://github.com/readthedocs/readthedocs.org/issues/1139
-# DON'T FORGET: Check the box "Install your project inside a virtualenv using
-# setup.py install" in the RTD Advanced Settings.
-# Additionally it helps us to avoid running apidoc manually
-
-try:  # for Sphinx >= 1.7
-    from sphinx.ext import apidoc
-except ImportError:
-    from sphinx import apidoc
+# -- Dynamically generated docs ----------------------------------------------
+import _gendocs
 
 output_dir = os.path.join(__location__, "api")
 module_dir = os.path.join(__location__, "../src/validate_pyproject")
-try:
-    shutil.rmtree(output_dir)
-except FileNotFoundError:
-    pass
-
-try:
-    import sphinx
-
-    cmd_line = f"sphinx-apidoc --implicit-namespaces -f -o {output_dir} {module_dir}"
-
-    args = cmd_line.split(" ")
-    if tuple(sphinx.__version__.split(".")) >= ("1", "7"):
-        # This is a rudimentary parse_version to avoid external dependencies
-        args = args[1:]
-
-    apidoc.main(args)
-except Exception as e:
-    print("Running `sphinx-apidoc` failed!")
-    print(e)
+_gendocs.gen_stubs(module_dir, output_dir)
 
 # -- General configuration ---------------------------------------------------
 
@@ -323,6 +291,7 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     "setuptools": ("https://setuptools.pypa.io/en/stable/", None),
     "pyscaffold": ("https://pyscaffold.org/en/stable", None),
+    "fastjsonschema": ("https://horejsek.github.io/python-fastjsonschema/", None),
 }
 extlinks = {
     "issue": (f"{repository}/issues/%s", "issue #%s"),

--- a/docs/embedding.rst
+++ b/docs/embedding.rst
@@ -27,25 +27,25 @@ via CLI as indicated in the command below:
 
     # in you terminal
     $ python -m validate_pyproject.pre_compile --help
-    $ python -m validate_pyproject.pre_compile -O dir/for/genereated_files
+    $ python -m validate_pyproject.pre_compile -O dir/for/generated_files
 
 This command will generate a few files under the directory given to the CLI.
 Please notice this directory should, ideally, be empty, and will correspond to
 a "sub-package" in your package (a ``__init__.py`` file will be generated,
 together with a few other ones).
 
-Assuming you have created a ``genereated_files`` directory, and that the value
+Assuming you have created a ``generated_files`` directory, and that the value
 for the ``--main-file`` option in the CLI was kept as the default
 ``__init__.py``, you should be able to invoke the validation function in your
 code by doing:
 
 .. code-block:: python
 
-    from .genereated_files import validate, JsonSchemaValueException
+    from .generated_files import validate, ValidationError
 
     try:
         validate(dict_representing_the_parsed_toml_file)
-    except JsonSchemaValueException:
+    except ValidationError:
         print("Invalid File")
 
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -61,6 +61,12 @@ The text on the standard is:
 This information is confirmed in a `similar document submitted to the IETF`_.
 
 
+Where do I find information about *format* X?
+=============================================
+
+Please check :doc:`/api/validate_pyproject.formats`.
+
+
 .. _if-then-else: https://json-schema.org/understanding-json-schema/reference/conditionals.html
 .. _issue: https://github.com/pypa/setuptools/issues/2671
 .. _JSON Schema: https://json-schema.org/

--- a/docs/modules.rst.in
+++ b/docs/modules.rst.in
@@ -6,7 +6,7 @@ Users may also import :mod:`validate_pyproject.errors` and :mod:`validate_pyproj
 when handling exceptions or specifying type hints.
 
 In addition to that, special `formats <https://json-schema.org/understanding-json-schema/reference/string#format>`_
-that can be used in the JSON Schema definitions are implemented in :mod:`validate_pyproject.format`.
+that can be used in the JSON Schema definitions are implemented in :mod:`validate_pyproject.formats`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/modules.rst.in
+++ b/docs/modules.rst.in
@@ -1,0 +1,17 @@
+Module Reference
+================
+
+The public API of ``validate-pyproject`` is exposed in the :mod:`validate_pyproject.api` module.
+Users may also import :mod:`validate_pyproject.errors` and :mod:`validate_pyproject.types`
+when handling exceptions or specifying type hints.
+
+In addition to that, special `formats <https://json-schema.org/understanding-json-schema/reference/string#format>`_
+that can be used in the JSON Schema definitions are implemented in :mod:`validate_pyproject.format`.
+
+.. toctree::
+   :maxdepth: 2
+
+   validate_pyproject.api
+   validate_pyproject.errors
+   validate_pyproject.types
+   validate_pyproject.formats

--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -41,6 +41,7 @@ try:  # pragma: no cover
         from importlib.resources import files
 
     def read_text(package: Union[str, ModuleType], resource: str) -> str:
+        """:meta private:"""
         return files(package).joinpath(resource).read_text(encoding="utf-8")  # type: ignore[no-any-return]
 
 except ImportError:  # pragma: no cover
@@ -48,7 +49,7 @@ except ImportError:  # pragma: no cover
 
 
 T = TypeVar("T", bound=Mapping)
-AllPlugins = Enum("AllPlugins", "ALL_PLUGINS")
+AllPlugins = Enum("AllPlugins", "ALL_PLUGINS")  #: :meta private:
 ALL_PLUGINS = AllPlugins.ALL_PLUGINS
 
 TOP_LEVEL_SCHEMA = "pyproject_toml"
@@ -69,11 +70,14 @@ FORMAT_FUNCTIONS = MappingProxyType(_get_public_functions(formats))
 def load(name: str, package: str = __package__, ext: str = ".schema.json") -> Schema:
     """Load the schema from a JSON Schema file.
     The returned dict-like object is immutable.
+
+    :meta private: (low level detail)
     """
     return Schema(json.loads(read_text(package, f"{name}{ext}")))
 
 
 def load_builtin_plugin(name: str) -> Schema:
+    """:meta private: (low level detail)"""
     return load(name, f"{__package__}.plugins")
 
 
@@ -86,6 +90,8 @@ class SchemaRegistry(Mapping[str, Schema]):
 
     Since this object work as a mapping between each schema ``$id`` and the schema
     itself, all schemas provided by plugins **MUST** have a top level ``$id``.
+
+    :meta private: (low level detail)
     """
 
     def __init__(self, plugins: Sequence["PluginProtocol"] = ()):
@@ -159,6 +165,8 @@ class RefHandler(Mapping[str, Callable[[str], Schema]]):
     into a function that receives the schema URI and returns the schema (as parsed JSON)
     (otherwise :mod:`urllib` is used and the URI is assumed to be a valid URL).
     This class will ensure all the URIs are loaded from the local registry.
+
+    :meta private: (low level detail)
     """
 
     def __init__(self, registry: Mapping[str, Schema]):
@@ -244,6 +252,9 @@ class Validator:
         return self._schema_registry[schema_id]
 
     def __call__(self, pyproject: T) -> T:
+        """Checks a parsed ``pyproject.toml`` file (given as :obj:`typing.Mapping`)
+        and raises an exception when it is not a valid.
+        """
         if self._cache is None:
             compiled = FJS.compile(self.schema, self.handlers, dict(self.formats))
             fn = partial(compiled, custom_formats=self._format_validators)

--- a/src/validate_pyproject/error_reporting.py
+++ b/src/validate_pyproject/error_reporting.py
@@ -45,6 +45,11 @@ _TOML_JARGON = {
     "property names": "keys",
 }
 
+_FORMATS_HELP = """
+For more details about `format` see
+https://validate-pyproject.readthedocs.io/en/latest/api/validate_pyproject.formats.html
+"""
+
 
 class ValidationError(JsonSchemaValueException):
     """Report violations of a given JSON schema.
@@ -160,7 +165,9 @@ class _ErrorFormatting:
             f"OFFENDING RULE: {self.ex.rule!r}",
             f"DEFINITION:\n{indent(schema, '    ')}",
         ]
-        return "\n\n".join(optional + defaults)
+        msg = "\n\n".join(optional + defaults)
+        epilog = f"\n{_FORMATS_HELP}" if "format" in msg.lower() else ""
+        return msg + epilog
 
 
 class _SummaryWriter:

--- a/src/validate_pyproject/errors.py
+++ b/src/validate_pyproject/errors.py
@@ -1,9 +1,18 @@
+"""
+In general, users should expect :obj:`validate_pyproject.errors.ValidationError`
+from :obj:`validate_pyproject.api.Validator.__call__`.
+
+Note that ``validate-pyproject`` derives most of its exceptions from
+:mod:`fastjsonschema`, so it might make sense to also have a look on
+:obj:`JsonSchemaException`, :obj:`JsonSchemaValueException` and
+:obj:`fastjsonschema.JsonSchemaDefinitionException`.
+)
+"""
+
 from textwrap import dedent
 
 from fastjsonschema import (
-    JsonSchemaDefinitionException,
-    JsonSchemaException,
-    JsonSchemaValueException,
+    JsonSchemaDefinitionException as _JsonSchemaDefinitionException,
 )
 
 from .error_reporting import ValidationError
@@ -24,7 +33,7 @@ class URLMissingTool(RuntimeError):
         super().__init__(msg)
 
 
-class InvalidSchemaVersion(JsonSchemaDefinitionException):
+class InvalidSchemaVersion(_JsonSchemaDefinitionException):
     _DESC = """\
     All schemas used in the validator should be specified using the same version \
     as the toplevel schema ({version!r}).
@@ -39,7 +48,7 @@ class InvalidSchemaVersion(JsonSchemaDefinitionException):
         super().__init__(msg)
 
 
-class SchemaMissingId(JsonSchemaDefinitionException):
+class SchemaMissingId(_JsonSchemaDefinitionException):
     _DESC = """\
     All schemas used in the validator MUST define a unique toplevel `"$id"`.
     No `"$id"` was found for schema associated with {reference!r}.
@@ -51,7 +60,7 @@ class SchemaMissingId(JsonSchemaDefinitionException):
         super().__init__(msg.format(reference=reference))
 
 
-class SchemaWithDuplicatedId(JsonSchemaDefinitionException):
+class SchemaWithDuplicatedId(_JsonSchemaDefinitionException):
     _DESC = """\
     All schemas used in the validator MUST define a unique toplevel `"$id"`.
     `$id = {schema_id!r}` was found at least twice.
@@ -65,9 +74,6 @@ class SchemaWithDuplicatedId(JsonSchemaDefinitionException):
 
 __all__ = [
     "InvalidSchemaVersion",
-    "JsonSchemaDefinitionException",
-    "JsonSchemaException",
-    "JsonSchemaValueException",
     "SchemaMissingId",
     "SchemaWithDuplicatedId",
     "ValidationError",

--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -1,5 +1,5 @@
 """
-The functions in this module are used to validate schemas that use the
+The functions in this module are used to validate schemas with the
 `format JSON Schema keyword
 <https://json-schema.org/understanding-json-schema/reference/string#format>`_.
 

--- a/tests/test_error_reporting.py
+++ b/tests/test_error_reporting.py
@@ -62,6 +62,8 @@ EXAMPLES = {
                         }
                     ]
                 }
+
+            For more details about `format` see
         """,
     },
     "description": {


### PR DESCRIPTION
Right now the pages generated with `sphinx-apidoc` is a bit all over the place:

![apidoc output](https://github.com/abravalheri/validate-pyproject/assets/320755/7f9d2b00-b1ba-4bb5-98b1-4c7ed6c4edba)

The idea of this change is to improve that and concentrate in the parts that make sense to expose as public.

It also improve some docstrings.