### PR TITLE
Relax requirements about module names to also allow dash characters

### DIFF
--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -289,6 +289,25 @@ def python_module_name(value: str) -> bool:
     return python_qualified_identifier(value)
 
 
+def python_module_name_relaxed(value: str) -> bool:
+    """Similar to :obj:`python_module_name`, but relaxed to also accept
+    dash characters (``-``) and cover special cases like ``pip-run``.
+
+    It is recommended, however, that beginners avoid dash characters,
+    as they require advanced knowledge about Python internals.
+
+    The following are disallowed:
+
+    * names starting/ending in dashes,
+    * names ending in ``-stubs`` (potentially collide with :obj:`pep561_stub_name`).
+    """
+    if value.startswith("-") or value.endswith("-"):
+        return False
+    if value.endswith("-stubs"):
+        return False  # Avoid collision with PEP 561
+    return python_module_name(value.replace("-", "_"))
+
+
 def python_entrypoint_group(value: str) -> bool:
     """See ``Data model > group`` in the :ref:`PyPA's entry-points specification
     <pypa:entry-points>`.

--- a/src/validate_pyproject/plugins/setuptools.schema.json
+++ b/src/validate_pyproject/plugins/setuptools.schema.json
@@ -148,14 +148,14 @@
     },
     "namespace-packages": {
       "type": "array",
-      "items": {"type": "string", "format": "python-module-name"},
+      "items": {"type": "string", "format": "python-module-name-relaxed"},
       "$comment": "https://setuptools.pypa.io/en/latest/userguide/package_discovery.html",
       "description": "**DEPRECATED**: use implicit namespaces instead (:pep:`420`)."
     },
     "py-modules": {
       "description": "Modules that setuptools will manipulate",
       "type": "array",
-      "items": {"type": "string", "format": "python-module-name"},
+      "items": {"type": "string", "format": "python-module-name-relaxed"},
       "$comment": "TODO: clarify the relationship with ``packages``"
     },
     "data-files": {
@@ -250,7 +250,7 @@
       "description": "Valid package name (importable or :pep:`561`).",
       "type": "string",
       "anyOf": [
-        {"type": "string", "format": "python-module-name"},
+        {"type": "string", "format": "python-module-name-relaxed"},
         {"type": "string", "format": "pep561-stub-name"}
       ]
     },

--- a/tests/invalid-examples/setuptools/packages/invalid-name.errors.txt
+++ b/tests/invalid-examples/setuptools/packages/invalid-name.errors.txt
@@ -1,3 +1,3 @@
 `tool.setuptools.packages` must be valid exactly by one definition
-{type: string, format: 'python-module-name'}
+{type: string, format: 'python-module-name-relaxed'}
 {type: string, format: 'pep561-stub-name'}

--- a/tests/invalid-examples/setuptools/packages/invalid-name.toml
+++ b/tests/invalid-examples/setuptools/packages/invalid-name.toml
@@ -9,4 +9,4 @@ version = "0.0.0"
 
 [tool.setuptools]
 platforms = ["any"]
-packages = ["not-an-identifier"]
+packages = ["-not-a-valid-name"]

--- a/tests/invalid-examples/setuptools/packages/invalid-stub-name.errors.txt
+++ b/tests/invalid-examples/setuptools/packages/invalid-stub-name.errors.txt
@@ -1,3 +1,3 @@
 `tool.setuptools.packages` must be valid exactly by one definition
-{type: string, format: 'python-module-name'}
+{type: string, format: 'python-module-name-relaxed'}
 {type: string, format: 'pep561-stub-name'}

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -267,6 +267,32 @@ def test_invalid_module_name(example):
     assert formats.python_module_name(example) is False
 
 
+@pytest.mark.parametrize(
+    "example",
+    [
+        "pip-run",
+        "abc-d-λ",
+        "abc-d-λ.xyz-e",
+        "abc-d.λ-xyz-e",
+    ],
+)
+def test_valid_module_name_relaxed(example):
+    assert formats.python_module_name_relaxed(example) is True
+
+
+@pytest.mark.parametrize(
+    "example",
+    [
+        "pip run",
+        "-pip-run",
+        "pip-run-",
+        "pip-run-stubs",
+    ],
+)
+def test_invalid_module_name_relaxed(example):
+    assert formats.python_module_name_relaxed(example) is False
+
+
 class TestClassifiers:
     """The ``_TroveClassifier`` class and ``_download_classifiers`` are part of the
     private API and therefore need to be tested.


### PR DESCRIPTION
Closes #162.

See details of the discussion in https://github.com/pypa/setuptools/issues/4316#issuecomment-2068123376. 