### PR TITLE
ci: macos-latest now points at macos-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         - "3.11"  # newest Python that is stable
         platform:
         - ubuntu-latest
-        - macos-latest
+        - macos-13
         - windows-latest
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
ARM is fine, but no Python 3.9 or earlier is not.