### PR TITLE
Align `tool.setuptools.dynamic.optional-dependencies` with `project.optional-dependencies`

### DIFF
--- a/src/validate_pyproject/plugins/setuptools.schema.json
+++ b/src/validate_pyproject/plugins/setuptools.schema.json
@@ -219,7 +219,7 @@
         "dependencies": {"$ref": "#/definitions/file-directive-for-dependencies"},
         "optional-dependencies": {
           "type": "object",
-          "propertyNames": {"type": "string", "format": "python-identifier"},
+          "propertyNames": {"type": "string", "format": "pep508-identifier"},
           "additionalProperties": false,
           "patternProperties": {
             ".+": {"$ref": "#/definitions/file-directive-for-dependencies"}

--- a/tests/examples/setuptools/10-pyproject.toml
+++ b/tests/examples/setuptools/10-pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "myproj"
+version = "42"
+dynamic = ["optional-dependencies"]
+
+[tool.setuptools.dynamic.optional-dependencies]
+name-with-hyfens = {file = "extra.txt"}

--- a/tests/invalid-examples/setuptools/dependencies/invalid-extra-name.errors.txt
+++ b/tests/invalid-examples/setuptools/dependencies/invalid-extra-name.errors.txt
@@ -1,3 +1,3 @@
 `tool.setuptools.dynamic.optional-dependencies` keys must be named by:
 
-    {type: string, format: 'python-identifier'}
+    {type: string, format: 'pep508-identifier'}


### PR DESCRIPTION
By analysing https://github.com/pypa/setuptools/issues/4341 we can see that currently `tool.setuptools.dynamic.optional-dependencies` differs from `project.optional-dependencies`.

They probably should be the same.

[PEP 685](https://peps.python.org/pep-0685/) also mentions that
> The [core metadata](https://packaging.python.org/en/latest/specifications/core-metadata/) specification will be updated such that the allowed names for [Provides-Extra](https://packaging.python.org/en/latest/specifications/core-metadata/#provides-extra-multiple-use) matches what [PEP 508](https://hugovk-peps.readthedocs.io/en/latest/pep-0508/) specifies for names.

So that makes sense for me.