### PR TITLE
Allow overwrite when schemas refer to the same `tool`

### DIFF
--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -90,7 +90,9 @@ def iterate_entry_points(group: str = ENTRYPOINT_GROUP) -> Iterable[EntryPoint]:
         # TODO: Once Python 3.10 becomes the oldest version supported, this fallback and
         #       conditional statement can be removed.
         entries_ = (plugin for plugin in entries.get(group, []))
-    deduplicated = {e.name: e for e in sorted(entries_, key=lambda e: e.name)}
+    deduplicated = {
+        e.name: e for e in sorted(entries_, key=lambda e: (e.name, e.value))
+    }
     return list(deduplicated.values())
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,7 +43,7 @@ class TestRegistry:
 
     def fake_plugin(self, name, schema_version=7, end="#"):
         schema = {
-            "$id": id or f"https://example.com/{name}.schema.json",
+            "$id": f"https://example.com/{name}.schema.json",
             "$schema": f"http://json-schema.org/draft-{schema_version:02d}/schema{end}",
             "type": "object",
         }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,7 +65,7 @@ class TestRegistry:
 
     def test_duplicated_id_different_tools(self):
         schema = self.fake_plugin("plg")
-        fn = wraps(self.fake_plugin)(lambda *_1, **_2: schema)  # Same ID
+        fn = wraps(self.fake_plugin)(lambda _: schema)  # Same ID
         plg = [plugins.PluginWrapper(f"plg{i}", fn) for i in range(2)]
         with pytest.raises(errors.SchemaWithDuplicatedId):
             api.SchemaRegistry(plg)


### PR DESCRIPTION
This is one of the possibilities discussed in #174.

It seems to me that we should allow `--tool` (for example) to overwrite a plugin given by entry-points. We might have to re-evaluate this when adding the possibility of "side-loading" non-tool plugins.

I am not 100% sure if there are other unforeseen consequences of this change.

Multiple entry-points might also try to redefine the same entry? So we might want to improve the sorting to improve reproducibility.