### PR TITLE
pyproject.toml: remove src from testpaths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ addopts = """
     --strict-markers
 """
 norecursedirs = ["dist", "build", ".tox"]
-testpaths = ["src", "tests"]
+testpaths = ["tests"]
 
 [tool.mypy]
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]


### PR DESCRIPTION
To fix regression introduced a month ago.

Fixes #200.