### PR TITLE
ci: fix Cirrus macOS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -120,7 +120,7 @@ mamba_task:
 macos_task:
   name: test (macOS - brew)
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-xcode
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
   brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
   install_script: brew install python tox pipx
   env:


### PR DESCRIPTION
Will move to ghcr.io/cirruslabs/macos-runner:sonoma if possible as that's supposed to be optimized for startup. https://github.com/cirruslabs/macos-image-templates?tab=readme-ov-file#update-cadence