### PR TITLE
Addopt `--import-mode=importlib` for pytest to prevent errors with `importlib.metadata`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ addopts = """
     --strict-markers
     --verbose
 """
-norecursedirs = ["dist", "build", ".tox"]
+norecursedirs = ["dist", "build", ".*"]
 testpaths = ["src", "tests"]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ all = [
 store = ["validate-pyproject-schema-store"]
 testing = [
     "setuptools",
-    "pytest",
+    "pytest>=8.3.3",
     "pytest-cov",
     "pytest-xdist",
     "pytest-randomly",
@@ -67,11 +67,12 @@ version_scheme = "no-guess-dev"
 
 [tool.pytest.ini_options]
 addopts = """
+    --import-mode importlib
     --cov validate_pyproject
     --cov-report term-missing
     --doctest-modules
-    --verbose
     --strict-markers
+    --verbose
 """
 norecursedirs = ["dist", "build", ".tox"]
 testpaths = ["src", "tests"]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ extras =
     all
     testing
 commands =
-    pytest --doctest-modules src
     pytest {posargs}
 
 


### PR DESCRIPTION
Closes #200 
Possibly obviates #201 

The key aspect for the solution seems to be a `pytest` update and using `importlib` mode.