### PR TITLE
Update `setuptools.schema.json`

### DIFF
--- a/src/validate_pyproject/plugins/setuptools.schema.json
+++ b/src/validate_pyproject/plugins/setuptools.schema.json
@@ -158,6 +158,11 @@
       "items": {"type": "string", "format": "python-module-name-relaxed"},
       "$comment": "TODO: clarify the relationship with ``packages``"
     },
+    "ext-modules": {
+      "description": "Extension modules to be compiled by setuptools",
+      "type": "array",
+      "items": {"$ref": "#/definitions/ext-module"}
+    },
     "data-files": {
       "$$description": [
         "``dict``-like structure where each key represents a directory and",
@@ -253,6 +258,82 @@
         {"type": "string", "format": "python-module-name-relaxed"},
         {"type": "string", "format": "pep561-stub-name"}
       ]
+    },
+    "ext-module": {
+      "$id": "#/definitions/ext-module",
+      "title": "Extension module",
+      "description": "Parameters to construct a :class:`setuptools.Extension` object",
+      "type": "object",
+      "required": ["name", "sources"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "format": "python-module-name-relaxed"
+        },
+        "sources": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "include-dirs":{
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "define-macros": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {"description": "macro name", "type": "string"},
+              {"description": "macro value", "oneOf": [{"type": "string"}, {"type": "null"}]}
+            ],
+            "additionalItems": false
+          }
+        },
+        "undef-macros": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "library-dirs": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "libraries": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "runtime-library-dirs": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "extra-objects": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "extra-compile-args": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "extra-link-args": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "export-symbols": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "swig-opts": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "depends": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "language": {"type": "string"},
+        "optional": {"type": "boolean"},
+        "py-limited-api": {"type": "boolean"}
+      }
     },
     "file-directive": {
       "$id": "#/definitions/file-directive",

--- a/tests/examples/setuptools/11-pyproject.toml
+++ b/tests/examples/setuptools/11-pyproject.toml
@@ -1,0 +1,4 @@
+[tool.setuptools]
+ext-modules = [
+  {name = "my.ext", sources = ["hello.c", "world.c"]}
+]

--- a/tests/examples/setuptools/12-pyproject.toml
+++ b/tests/examples/setuptools/12-pyproject.toml
@@ -1,0 +1,3 @@
+[[tool.setuptools.ext-modules]]
+name = "my.ext"
+sources = ["hello.c", "world.c"]

--- a/tests/invalid-examples/setuptools/ext-modules/invalid-field.errors.txt
+++ b/tests/invalid-examples/setuptools/ext-modules/invalid-field.errors.txt
@@ -1,0 +1,1 @@
+must not contain {'non-existing-field'}

--- a/tests/invalid-examples/setuptools/ext-modules/invalid-field.toml
+++ b/tests/invalid-examples/setuptools/ext-modules/invalid-field.toml
@@ -1,0 +1,4 @@
+[[tool.setuptools.ext-modules]]
+name = "hello.world"
+sources = ["hello.c"]
+non-existing-field = "hello"

--- a/tests/invalid-examples/setuptools/ext-modules/invalid-sources.errors.txt
+++ b/tests/invalid-examples/setuptools/ext-modules/invalid-sources.errors.txt
@@ -1,0 +1,1 @@
+must be array

--- a/tests/invalid-examples/setuptools/ext-modules/invalid-sources.toml
+++ b/tests/invalid-examples/setuptools/ext-modules/invalid-sources.toml
@@ -1,0 +1,3 @@
+[[tool.setuptools.ext-modules]]
+name = "hello.world"
+sources = "hello.c"

--- a/tests/invalid-examples/setuptools/ext-modules/missing-ext-name.errors.txt
+++ b/tests/invalid-examples/setuptools/ext-modules/missing-ext-name.errors.txt
@@ -1,0 +1,1 @@
+must contain ['name']

--- a/tests/invalid-examples/setuptools/ext-modules/missing-ext-name.toml
+++ b/tests/invalid-examples/setuptools/ext-modules/missing-ext-name.toml
@@ -1,0 +1,2 @@
+[[tool.setuptools.ext-modules]]
+sources = ["hello.c", "world.c"]


### PR DESCRIPTION
This is a reaction to the latest changes in the setuptools repository, that now allows static `ext_modules` to be defined in ``pyproject.toml``.

At some point, it is probably good to handover the setuptools schemas to setuptools itself and integrate via entry-points.