### PR TITLE
feat: support PEP 735

### DIFF
--- a/src/validate_pyproject/extra_validations.py
+++ b/src/validate_pyproject/extra_validations.py
@@ -75,7 +75,7 @@ def validate_include_depenency(pyproject: T) -> T:
                         "description": cleandoc(IncludedDependencyGroupMustExist._DESC),
                         "see": IncludedDependencyGroupMustExist._URL,
                     },
-                    rule="PEP 621",
+                    rule="PEP 735",
                 )
     # TODO: check for `include-group` cycles (can be conditional to graphlib)
     return pyproject

--- a/src/validate_pyproject/extra_validations.py
+++ b/src/validate_pyproject/extra_validations.py
@@ -67,9 +67,7 @@ def validate_include_depenency(pyproject: T) -> T:
             ):
                 raise IncludedDependencyGroupMustExist(
                     message=f"The included dependency group {include_group} doesn't exist",
-                    value={
-                        "field": include_group,
-                    },
+                    value=each,
                     name=f"data.dependency_groups.{key}",
                     definition={
                         "description": cleandoc(IncludedDependencyGroupMustExist._DESC),

--- a/src/validate_pyproject/extra_validations.py
+++ b/src/validate_pyproject/extra_validations.py
@@ -77,6 +77,7 @@ def validate_include_depenency(pyproject: T) -> T:
                     },
                     rule="PEP 621",
                 )
+    # TODO: check for `include-group` cycles (can be conditional to graphlib)
     return pyproject
 
 

--- a/src/validate_pyproject/extra_validations.py
+++ b/src/validate_pyproject/extra_validations.py
@@ -24,6 +24,13 @@ class RedefiningStaticFieldAsDynamic(ValidationError):
     )
 
 
+class IncludedDependencyGroupMustExist(ValidationError):
+    _DESC = """An included dependency group must exist and must not be cyclic.
+    """
+    __doc__ = _DESC
+    _URL = "https://peps.python.org/pep-0735/"
+
+
 def validate_project_dynamic(pyproject: T) -> T:
     project_table = pyproject.get("project", {})
     dynamic = project_table.get("dynamic", [])
@@ -49,4 +56,28 @@ def validate_project_dynamic(pyproject: T) -> T:
     return pyproject
 
 
-EXTRA_VALIDATIONS = (validate_project_dynamic,)
+def validate_include_depenency(pyproject: T) -> T:
+    dependency_groups = pyproject.get("dependency-groups", {})
+    for key, value in dependency_groups.items():
+        for each in value:
+            if (
+                isinstance(each, dict)
+                and (include_group := each.get("include-group"))
+                and include_group not in dependency_groups
+            ):
+                raise IncludedDependencyGroupMustExist(
+                    message=f"The included dependency group {include_group} doesn't exist",
+                    value={
+                        "field": include_group,
+                    },
+                    name=f"data.dependency_groups.{key}",
+                    definition={
+                        "description": cleandoc(IncludedDependencyGroupMustExist._DESC),
+                        "see": IncludedDependencyGroupMustExist._URL,
+                    },
+                    rule="PEP 621",
+                )
+    return pyproject
+
+
+EXTRA_VALIDATIONS = (validate_project_dynamic, validate_include_depenency)

--- a/src/validate_pyproject/pyproject_toml.schema.json
+++ b/src/validate_pyproject/pyproject_toml.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-
   "$id": "https://packaging.python.org/en/latest/specifications/declaring-build-dependencies/",
   "title": "Data structure for ``pyproject.toml`` files",
   "$$description": [
@@ -60,6 +59,36 @@
 
     "tool": {
       "type": "object"
+    },
+    "dependency-groups": {
+      "type": "object",
+      "description": "Dependency groups following PEP 735",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "Python package specifiers following PEP 508",
+                "format": "pep508"
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "include-group": {
+                    "description": "Another dependency group to include in this one",
+                    "type": "string",
+                    "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
     }
   }
 }

--- a/tests/examples/simple/depgroups.toml
+++ b/tests/examples/simple/depgroups.toml
@@ -1,0 +1,3 @@
+[dependency-groups]
+test = ["one", "two"]
+other = ["one", {include-group = "test"}]

--- a/tests/invalid-examples/pep735/invalid-group.errors.txt
+++ b/tests/invalid-examples/pep735/invalid-group.errors.txt
@@ -1,0 +1,1 @@
+dependency-groups` must not contain {'a b'} properties

--- a/tests/invalid-examples/pep735/invalid-group.toml
+++ b/tests/invalid-examples/pep735/invalid-group.toml
@@ -1,0 +1,2 @@
+[dependency-groups]
+"a b" = ["one"]

--- a/tests/invalid-examples/pep735/invalid-key.errors.txt
+++ b/tests/invalid-examples/pep735/invalid-key.errors.txt
@@ -1,0 +1,1 @@
+`dependency-groups.mydep[1]` must be valid exactly by one definition

--- a/tests/invalid-examples/pep735/invalid-key.toml
+++ b/tests/invalid-examples/pep735/invalid-key.toml
@@ -1,0 +1,2 @@
+[dependency-groups]
+mydep = ["one", {other = "two"}]

--- a/tests/invalid-examples/pep735/not-pep508.errors.txt
+++ b/tests/invalid-examples/pep735/not-pep508.errors.txt
@@ -1,0 +1,1 @@
+`dependency-groups.test[0]` must be valid exactly by one definition (0 matches found)

--- a/tests/invalid-examples/pep735/not-pep508.toml
+++ b/tests/invalid-examples/pep735/not-pep508.toml
@@ -1,0 +1,2 @@
+[dependency-groups]
+test = [" "]


### PR DESCRIPTION
Add support for validating PEP 735.

Pretty sure we can't validate that include-groups point to an existing group without custom code. Though maybe there is custom code for `dynamic` already? It doesn't seem to be part of the schema like in SchemaStore's version.