### PR TITLE
feat: support PEP 639

### DIFF
--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -376,3 +376,8 @@ def uint(value: builtins.int) -> bool:
 def int(value: builtins.int) -> bool:
     r"""Signed 64-bit integer (:math:`-2^{63} \leq x < 2^{63}`)"""
     return -(2**63) <= value < 2**63
+
+
+def SPDX(value: str) -> bool:
+    """Should validate eventually"""
+    return True

--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -380,4 +380,5 @@ def int(value: builtins.int) -> bool:
 
 def SPDX(value: str) -> bool:
     """Should validate eventually"""
+    # TODO: validate conditional to the presence of (the right version) of packaging
     return True

--- a/src/validate_pyproject/project_metadata.schema.json
+++ b/src/validate_pyproject/project_metadata.schema.json
@@ -104,6 +104,12 @@
         "`Project license <https://peps.python.org/pep-0621/#license>`_.",
       "oneOf": [
         {
+          "type": "string",
+          "description": "An SPDX license identifier",
+          "format": "SPDX"
+        },
+        {
+          "type": "object",
           "properties": {
             "file": {
               "type": "string",
@@ -116,6 +122,7 @@
           "required": ["file"]
         },
         {
+          "type": "object",
           "properties": {
             "text": {
               "type": "string",
@@ -129,6 +136,13 @@
           "required": ["text"]
         }
       ]
+    },
+    "license-files": {
+      "description": "Paths or globs to paths of license files",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "authors": {
       "type": "array",
@@ -232,6 +246,7 @@
           "readme",
           "requires-python",
           "license",
+          "license-files",
           "authors",
           "maintainers",
           "keywords",
@@ -248,32 +263,48 @@
   },
   "required": ["name"],
   "additionalProperties": false,
-  "if": {
-    "not": {
-      "required": ["dynamic"],
-      "properties": {
-        "dynamic": {
-          "contains": {"const": "version"},
-          "$$description": ["version is listed in ``dynamic``"]
-        }
+  "allOf": [
+    {
+      "if": {
+        "not": {
+          "required": ["dynamic"],
+          "properties": {
+            "dynamic": {
+              "contains": {"const": "version"},
+              "$$description": ["version is listed in ``dynamic``"]
+            }
+          }
+        },
+        "$$comment": [
+          "According to :pep:`621`:",
+          "    If the core metadata specification lists a field as \"Required\", then",
+          "    the metadata MUST specify the field statically or list it in dynamic",
+          "In turn, `core metadata`_ defines:",
+          "    The required fields are: Metadata-Version, Name, Version.",
+          "    All the other fields are optional.",
+          "Since ``Metadata-Version`` is defined by the build back-end, ``name`` and",
+          "``version`` are the only mandatory information in ``pyproject.toml``.",
+          ".. _core metadata: https://packaging.python.org/specifications/core-metadata/"
+        ]
+      },
+      "then": {
+        "required": ["version"],
+        "$$description": ["version should be statically defined in the ``version`` field"]
       }
     },
-    "$$comment": [
-      "According to :pep:`621`:",
-      "    If the core metadata specification lists a field as \"Required\", then",
-      "    the metadata MUST specify the field statically or list it in dynamic",
-      "In turn, `core metadata`_ defines:",
-      "    The required fields are: Metadata-Version, Name, Version.",
-      "    All the other fields are optional.",
-      "Since ``Metadata-Version`` is defined by the build back-end, ``name`` and",
-      "``version`` are the only mandatory information in ``pyproject.toml``.",
-      ".. _core metadata: https://packaging.python.org/specifications/core-metadata/"
-    ]
-  },
-  "then": {
-    "required": ["version"],
-    "$$description": ["version should be statically defined in the ``version`` field"]
-  },
+    {
+      "if": {
+        "required": ["license-files"]
+      },
+      "then": {
+        "properties": {
+          "license": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ],
 
   "definitions": {
     "author": {

--- a/tests/examples/simple/pep638.toml
+++ b/tests/examples/simple/pep638.toml
@@ -1,0 +1,5 @@
+[project]
+name = "example"
+version = "1.2.3"
+license = "MIT OR GPL-2.0-or-later OR (FSFUL AND BSD-2-Clause)"
+license-files = ["licenses/LICENSE.MIT", "licenses/LICENSE.CC0"]

--- a/tests/invalid-examples/pep621/pep639/bothstyles.errors.txt
+++ b/tests/invalid-examples/pep621/pep639/bothstyles.errors.txt
@@ -1,0 +1,1 @@
+`project.license` must be string

--- a/tests/invalid-examples/pep621/pep639/bothstyles.toml
+++ b/tests/invalid-examples/pep621/pep639/bothstyles.toml
@@ -1,0 +1,5 @@
+[project]
+name = "x"
+version = "1.2.3"
+license.text = "Something"
+license-files = ["value"]


### PR DESCRIPTION
Starting [PEP 639](https://peps.python.org/pep-0639/) support. It would be really nice to validate SPDX (wait for packaging?). I did make sure the incorrect combinations of license-files with non-string license is disallowed.

Close #70. I'm also adding support to SchemaStore's related file in https://github.com/SchemaStore/schemastore/pull/4143.