### PR TITLE
Add an option to disable using trove-classifiers package

### DIFF
--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -214,18 +214,18 @@ class _TroveClassifier:
         return value in self.downloaded or value.lower().startswith("private ::")
 
 
-try:
-    from trove_classifiers import classifiers as _trove_classifiers
-
-    def trove_classifier(value: str) -> bool:
-        """See https://pypi.org/classifiers/"""
-        return value in _trove_classifiers or value.lower().startswith("private ::")
-
-    if os.getenv("VALIDATE_PYPROJECT_NO_TROVE_CLASSIFIERS"):  # pragma: no cover
-        raise ImportError()
-
-except ImportError:  # pragma: no cover
+if os.getenv("VALIDATE_PYPROJECT_NO_TROVE_CLASSIFIERS"):
     trove_classifier = _TroveClassifier()
+else:
+    try:
+        from trove_classifiers import classifiers as _trove_classifiers
+    
+        def trove_classifier(value: str) -> bool:
+            """See https://pypi.org/classifiers/"""
+            return value in _trove_classifiers or value.lower().startswith("private ::")
+    
+    except ImportError:  # pragma: no cover
+        trove_classifier = _TroveClassifier()
 
 
 # -------------------------------------------------------------------------------------

--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -219,11 +219,11 @@ if os.getenv("VALIDATE_PYPROJECT_NO_TROVE_CLASSIFIERS"):
 else:
     try:
         from trove_classifiers import classifiers as _trove_classifiers
-    
+
         def trove_classifier(value: str) -> bool:
             """See https://pypi.org/classifiers/"""
             return value in _trove_classifiers or value.lower().startswith("private ::")
-    
+
     except ImportError:  # pragma: no cover
         trove_classifier = _TroveClassifier()
 

--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -214,7 +214,7 @@ class _TroveClassifier:
         return value in self.downloaded or value.lower().startswith("private ::")
 
 
-if os.getenv("VALIDATE_PYPROJECT_NO_TROVE_CLASSIFIERS"):
+if os.getenv("VALIDATE_PYPROJECT_NO_TROVE_CLASSIFIERS") and not typing.TYPE_CHECKING:
     trove_classifier = _TroveClassifier()
 else:
     try:

--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -221,6 +221,9 @@ try:
         """See https://pypi.org/classifiers/"""
         return value in _trove_classifiers or value.lower().startswith("private ::")
 
+    if os.getenv("VALIDATE_PYPROJECT_NO_TROVE_CLASSIFIERS"):  # pragma: no cover
+        raise ImportError()
+
 except ImportError:  # pragma: no cover
     trove_classifier = _TroveClassifier()
 


### PR DESCRIPTION
As requested in https://github.com/pypa/setuptools/issues/4459, add a VALIDATE_PYPROJECT_NO_TROVE_CLASSIFIERS environment variable that can be used to disable using trove_classifiers package even if it is available.  This can be used when the system features an outdated trove_classifiers, and therefore incorrectly triggers validation error. The change is designed to be absolutely minimal and non-intrusive.


-------

I do realize you're probably going to reject this. Nevertheless, I believe it makes sense to send a pull request, so others who need a similar change can easily discover it.