### PR TITLE
Fix tests failing due to missing partial-pdm-dockerize.json schema

### DIFF
--- a/tests/examples/store/test_config.json
+++ b/tests/examples/store/test_config.json
@@ -1,3 +1,6 @@
 {
-    "store": "https://json.schemastore.org/pyproject.json"
+    "store": "https://json.schemastore.org/pyproject.json",
+    "tools": {
+        "pdm-dockerize": "https://json.schemastore.org/partial-pdm-dockerize.json"
+    }
 }

--- a/tests/invalid-examples/store/test_config.json
+++ b/tests/invalid-examples/store/test_config.json
@@ -1,3 +1,6 @@
 {
-    "store": "https://json.schemastore.org/pyproject.json"
+    "store": "https://json.schemastore.org/pyproject.json",
+    "tools": {
+        "pdm-dockerize": "https://json.schemastore.org/partial-pdm-dockerize.json"
+    }
 }


### PR DESCRIPTION
Hey, Arch Linux maintainer here :wave:

Tests running on the examples in tests/examples/store/ and tests/invalid-examples/store/ currently fail with the following error from fastjsonschema:

    KeyError: 'https://json.schemastore.org/partial-pdm-dockerize.json'

I'm not sure why fastjsonschema cannot resolve the remote schema `partial-pdm-dockerize.json`. The reference chain seems to be:

    pyproject.json -> partial-pdm.json -> partial-pdm-dockerize.json

Work-around the above by adding partial-pdm-dockerize.json to the relevant `test_config.json` files.