### PR TITLE
chore: move to using dependency-groups

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,7 +78,7 @@ build_task:
   container: {image: "python:3.11-bullseye"}
   clone_script: *clone
   <<: *task-template
-  install_script: pip install tox
+  install_script: pip install tox tox-uv
   build_script:
     - tox -e clean,lint,typecheck,build
     - tar czf dist.tar.gz dist
@@ -102,7 +102,7 @@ linux_task:
       container: {image: "python:3.13-rc-bookworm"}
       allow_failures: true  # RC
   install_script:
-    - python -m pip install --upgrade pip tox pipx
+    - python -m pip install --upgrade pip tox tox-uv pipx
   <<: *test-template
   alias: base-test
 
@@ -149,7 +149,7 @@ windows_task:
     - choco install -y --no-progress python3 --version=3.12.5 --params "/NoLockdown"
     - choco install -y --no-progress curl
     - pip install --upgrade certifi
-    - python -m pip install -U pip tox pipx
+    - python -m pip install -U pip tox tox-uv pipx
   <<: *test-template
   depends_on: [build, base-test]
 
@@ -168,7 +168,7 @@ linkcheck_task:
   depends_on: [finalize]
   allow_failures: true
   <<: *task-template
-  install_script: pip install tox
+  install_script: pip install tox tox-uv
   download_artifact_script: *download-artifact
   linkcheck_script: tox --installpkg dist/*.whl -e linkcheck -- -q
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,23 +5,25 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: ubuntu-lts-latest
   tools:
-    python: "3.10"
+    python: latest
+  jobs:
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv $READTHEDOCS_VIRTUALENV_PATH
+    install:
+      # Use a cache dir in the same mount to halve the install time
+      # pip and uv pip will gain support for groups soon
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv sync --active --cache-dir $READTHEDOCS_VIRTUALENV_PATH/../../uv_cache --group docs --extra all
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
 # Optionally build your docs in additional formats such as PDF
 formats:
   - pdf
-
-python:
-  install:
-    - requirements: docs/requirements.txt
-    - {path: ., extra_requirements: [all], method: pip}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
-# Requirements file for ReadTheDocs, check .readthedocs.yml.
-# To build the module reference correctly, make sure every external package
-# under `install_requires` in `setup.cfg` is also listed here!
-furo>=2023.08.17
-sphinx>=7.2.2
-sphinx-argparse>=0.3.1
-sphinx-copybutton
-sphinx-jsonschema>=1.16.11
-sphinxemoji

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,32 @@ all = [
     "trove-classifiers>=2021.10.20",
 ]
 store = ["validate-pyproject-schema-store"]
+
+[project.scripts]
+validate-pyproject = "validate_pyproject.cli:main"
+
+[project.entry-points."validate_pyproject.tool_schema"]
+setuptools = "validate_pyproject.api:load_builtin_plugin"
+distutils = "validate_pyproject.api:load_builtin_plugin"
+
+[project.entry-points."repo_review.checks"]
+validate_pyproject = "validate_pyproject.repo_review:repo_review_checks"
+
+[project.entry-points."repo_review.families"]
+validate_pyproject = "validate_pyproject.repo_review:repo_review_families"
+
+[dependency-groups]
+dev = [
+    { include-group = "test" },
+]
+docs = [
+    "furo>=2023.08.17",
+    "sphinx>=7.2.2",
+    "sphinx-argparse>=0.3.1",
+    "sphinx-copybutton",
+    "sphinx-jsonschema>=1.16.11",
+    "sphinxemoji",
+]
 test = [
     "setuptools",
     "pytest>=8.3.3",
@@ -49,18 +75,13 @@ typecheck = [
     "importlib-resources",
 ]
 
-[project.scripts]
-validate-pyproject = "validate_pyproject.cli:main"
-
-[project.entry-points."validate_pyproject.tool_schema"]
-setuptools = "validate_pyproject.api:load_builtin_plugin"
-distutils = "validate_pyproject.api:load_builtin_plugin"
-
-[project.entry-points."repo_review.checks"]
-validate_pyproject = "validate_pyproject.repo_review:repo_review_checks"
-
-[project.entry-points."repo_review.families"]
-validate_pyproject = "validate_pyproject.repo_review:repo_review_families"
+[tool.uv]
+environments = [
+  "python_version >= '3.9'",
+]
+dev-dependencies = [
+  "validate_pyproject[all]",
+]
 
 [tool.setuptools_scm]
 version_scheme = "no-guess-dev"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # THIS SCRIPT IS SUPPOSED TO BE AN EXAMPLE. MODIFY IT ACCORDING TO YOUR NEEDS!
 
 [tox]
-minversion = 3.24
+minversion = 4.22
 envlist = default
 isolated_build = True
 
@@ -16,9 +16,8 @@ passenv =
     HOME
     SETUPTOOLS_*
     VALIDATE_PYPROJECT_*
-extras =
-    all
-    test
+dependency_groups = test
+extras = all
 commands =
     pytest {posargs}
 
@@ -42,9 +41,8 @@ changedir = {toxinidir}
 passenv =
     TERM
     # ^ ensure colors
-extras =
-    all
-    typecheck
+extras = all
+dependency_groups = typecheck
 commands =
     python -m mypy {posargs:--pretty --show-error-context src}
 
@@ -79,11 +77,8 @@ setenv =
     linkcheck: BUILD = linkcheck
 passenv =
     SETUPTOOLS_*
-extras =
-    all
-deps =
-    -r {toxinidir}/docs/requirements.txt
-    # ^  requirements.txt shared with Read The Docs
+extras = all
+dependency_groups = docs
 commands =
     sphinx-build -v -T -j auto --color -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
 


### PR DESCRIPTION
Trying something new for RtD, based on recent additions. https://github.com/readthedocs/readthedocs.org/issues/11289 Also using tox-uv to speed up CI. This has the added bonus that `uv run pytest` also just works out of the box, since it picks up the `dev` dependency group. (Note: uv is not required for people running tox, though, just the minimum version was bumped a bit, no other changes for users)

This cuts the readthedocs job time in half. Other jobs are faster, too.
