### PR TITLE
feat: multi-plugins with extra schemas

### DIFF
--- a/docs/dev-guide.rst
+++ b/docs/dev-guide.rst
@@ -154,6 +154,9 @@ An example of the plugin structure needed for this system is shown below:
             "schemas": [my_extra_schema],
         }
 
+Fragments for schemas are also supported with this system; use ``#`` to split
+the tool name and fragment path in the dictionary key.
+
 .. _entry-point: https://setuptools.pypa.io/en/stable/userguide/entry_point.html#entry-points
 .. _JSON Schema: https://json-schema.org/
 .. _Python package: https://packaging.python.org/

--- a/docs/dev-guide.rst
+++ b/docs/dev-guide.rst
@@ -89,7 +89,6 @@ can pass ``plugins=[]`` to the constructor; or, for example in the snippet
 above, we could have used ``plugins=...`` instead of ``extra_plugins=...``
 to ensure only the explicitly given plugins are loaded.
 
-
 Distributing Plugins
 --------------------
 
@@ -121,6 +120,39 @@ argument as same name as given to the entrypoint (e.g. :samp:`your_plugin({"your
 Also notice plugins are activated in a specific order, using Python's built-in
 ``sorted`` function.
 
+
+Providing multiple schemas
+--------------------------
+
+A second system is provided for providing multiple schemas in a single plugin.
+This is useful when a single plugin is responsible for multiple subtables
+under the ``tool`` table, or if you need to provide multiple schemas for a
+a single subtable.
+
+To use this system, the plugin function, which does not take any arguments,
+should return a dictionary with two keys: ``tools``, which is a dictionary of
+tool names to schemas, and optionally ``schemas``, which is a list of schemas
+that are not associated with any specific tool, but are loaded via ref's from
+the other tools.
+
+When using a :pep:`621`-compliant backend, the following can be add to your
+``pyproject.toml`` file:
+
+.. code-block:: toml
+
+    # in pyproject.toml
+    [project.entry-points."validate_pyproject.validate_pyproject.multi_schema"]
+    arbitrary = "your_package.your_module:your_plugin"
+
+An example of the plugin structure needed for this system is shown below:
+
+.. code-block:: python
+
+    def your_plugin(tool_name: str) -> dict:
+        return {
+            "tools": {"my-tool": my_schema},
+            "schemas": [my_extra_schema],
+        }
 
 .. _entry-point: https://setuptools.pypa.io/en/stable/userguide/entry_point.html#entry-points
 .. _JSON Schema: https://json-schema.org/

--- a/docs/dev-guide.rst
+++ b/docs/dev-guide.rst
@@ -89,6 +89,7 @@ can pass ``plugins=[]`` to the constructor; or, for example in the snippet
 above, we could have used ``plugins=...`` instead of ``extra_plugins=...``
 to ensure only the explicitly given plugins are loaded.
 
+
 Distributing Plugins
 --------------------
 

--- a/src/validate_pyproject/cli.py
+++ b/src/validate_pyproject/cli.py
@@ -24,14 +24,13 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
-    Union,
 )
 
 from . import __version__
 from . import _tomllib as tomllib
 from .api import Validator
 from .errors import ValidationError
-from .plugins import PluginWrapper, StoredPlugin
+from .plugins import PluginProtocol, PluginWrapper
 from .plugins import list_from_entry_points as list_plugins_from_entry_points
 from .remote import RemotePlugin, load_store
 
@@ -125,7 +124,7 @@ class CliParams(NamedTuple):
     dump_json: bool = False
 
 
-def __meta__(plugins: Sequence[Union[PluginWrapper, StoredPlugin]]) -> Dict[str, dict]:
+def __meta__(plugins: Sequence[PluginProtocol]) -> Dict[str, dict]:
     """'Hyper parameters' to instruct :mod:`argparse` how to create the CLI"""
     meta = {k: v.copy() for k, v in META.items()}
     meta["enable"]["choices"] = {p.tool for p in plugins}
@@ -136,11 +135,9 @@ def __meta__(plugins: Sequence[Union[PluginWrapper, StoredPlugin]]) -> Dict[str,
 @critical_logging()
 def parse_args(
     args: Sequence[str],
-    plugins: Sequence[Union[PluginWrapper, StoredPlugin]],
+    plugins: Sequence[PluginProtocol],
     description: str = "Validate a given TOML file",
-    get_parser_spec: Callable[
-        [Sequence[Union[PluginWrapper, StoredPlugin]]], Dict[str, dict]
-    ] = __meta__,
+    get_parser_spec: Callable[[Sequence[PluginProtocol]], Dict[str, dict]] = __meta__,
     params_class: Type[T] = CliParams,  # type: ignore[assignment]
 ) -> T:
     """Parse command line parameters
@@ -170,11 +167,14 @@ def parse_args(
     return params_class(**params)  # type: ignore[call-overload, no-any-return]
 
 
+Plugins = TypeVar("Plugins", bound=PluginProtocol)
+
+
 def select_plugins(
-    plugins: Sequence[Union[PluginWrapper, StoredPlugin]],
+    plugins: Sequence[Plugins],
     enabled: Sequence[str] = (),
     disabled: Sequence[str] = (),
-) -> List[Union[StoredPlugin, PluginWrapper]]:
+) -> List[Plugins]:
     available = list(plugins)
     if enabled:
         available = [p for p in available if p.tool in enabled]
@@ -222,7 +222,7 @@ def run(args: Sequence[str] = ()) -> int:
           (for example  ``["--verbose", "setup.cfg"]``).
     """
     args = args or sys.argv[1:]
-    plugins: List[Union[PluginWrapper, StoredPlugin]] = list_plugins_from_entry_points()
+    plugins = list_plugins_from_entry_points()
     params: CliParams = parse_args(args, plugins)
     setup_logging(params.loglevel)
     tool_plugins = [RemotePlugin.from_str(t) for t in params.tool]
@@ -266,7 +266,7 @@ class Formatter(argparse.RawTextHelpFormatter):
         return list(chain.from_iterable(wrap(x, width) for x in text.splitlines()))
 
 
-def plugins_help(plugins: Sequence[Union[PluginWrapper, StoredPlugin]]) -> str:
+def plugins_help(plugins: Sequence[PluginProtocol]) -> str:
     return "\n".join(_format_plugin_help(p) for p in plugins)
 
 
@@ -276,7 +276,7 @@ def _flatten_str(text: str) -> str:
     return (text[0].lower() + text[1:]).strip()
 
 
-def _format_plugin_help(plugin: Union[PluginWrapper, StoredPlugin]) -> str:
+def _format_plugin_help(plugin: PluginProtocol) -> str:
     help_text = plugin.help_text
     help_text = f": {_flatten_str(help_text)}" if help_text else ""
     return f"* {plugin.tool!r}{help_text}"

--- a/src/validate_pyproject/cli.py
+++ b/src/validate_pyproject/cli.py
@@ -24,13 +24,14 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
+    Union,
 )
 
 from . import __version__
 from . import _tomllib as tomllib
 from .api import Validator
 from .errors import ValidationError
-from .plugins import PluginWrapper
+from .plugins import PluginWrapper, StoredPlugin
 from .plugins import list_from_entry_points as list_plugins_from_entry_points
 from .remote import RemotePlugin, load_store
 
@@ -124,7 +125,7 @@ class CliParams(NamedTuple):
     dump_json: bool = False
 
 
-def __meta__(plugins: Sequence[PluginWrapper]) -> Dict[str, dict]:
+def __meta__(plugins: Sequence[Union[PluginWrapper, StoredPlugin]]) -> Dict[str, dict]:
     """'Hyper parameters' to instruct :mod:`argparse` how to create the CLI"""
     meta = {k: v.copy() for k, v in META.items()}
     meta["enable"]["choices"] = {p.tool for p in plugins}
@@ -135,9 +136,11 @@ def __meta__(plugins: Sequence[PluginWrapper]) -> Dict[str, dict]:
 @critical_logging()
 def parse_args(
     args: Sequence[str],
-    plugins: Sequence[PluginWrapper],
+    plugins: Sequence[Union[PluginWrapper, StoredPlugin]],
     description: str = "Validate a given TOML file",
-    get_parser_spec: Callable[[Sequence[PluginWrapper]], Dict[str, dict]] = __meta__,
+    get_parser_spec: Callable[
+        [Sequence[Union[PluginWrapper, StoredPlugin]]], Dict[str, dict]
+    ] = __meta__,
     params_class: Type[T] = CliParams,  # type: ignore[assignment]
 ) -> T:
     """Parse command line parameters
@@ -168,10 +171,10 @@ def parse_args(
 
 
 def select_plugins(
-    plugins: Sequence[PluginWrapper],
+    plugins: Sequence[Union[PluginWrapper, StoredPlugin]],
     enabled: Sequence[str] = (),
     disabled: Sequence[str] = (),
-) -> List[PluginWrapper]:
+) -> List[Union[StoredPlugin, PluginWrapper]]:
     available = list(plugins)
     if enabled:
         available = [p for p in available if p.tool in enabled]
@@ -219,7 +222,7 @@ def run(args: Sequence[str] = ()) -> int:
           (for example  ``["--verbose", "setup.cfg"]``).
     """
     args = args or sys.argv[1:]
-    plugins: List[PluginWrapper] = list_plugins_from_entry_points()
+    plugins: List[Union[PluginWrapper, StoredPlugin]] = list_plugins_from_entry_points()
     params: CliParams = parse_args(args, plugins)
     setup_logging(params.loglevel)
     tool_plugins = [RemotePlugin.from_str(t) for t in params.tool]
@@ -263,7 +266,7 @@ class Formatter(argparse.RawTextHelpFormatter):
         return list(chain.from_iterable(wrap(x, width) for x in text.splitlines()))
 
 
-def plugins_help(plugins: Sequence[PluginWrapper]) -> str:
+def plugins_help(plugins: Sequence[Union[PluginWrapper, StoredPlugin]]) -> str:
     return "\n".join(_format_plugin_help(p) for p in plugins)
 
 
@@ -273,7 +276,7 @@ def _flatten_str(text: str) -> str:
     return (text[0].lower() + text[1:]).strip()
 
 
-def _format_plugin_help(plugin: PluginWrapper) -> str:
+def _format_plugin_help(plugin: Union[PluginWrapper, StoredPlugin]) -> str:
     help_text = plugin.help_text
     help_text = f": {_flatten_str(help_text)}" if help_text else ""
     return f"* {plugin.tool!r}{help_text}"

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -143,7 +143,7 @@ def load_from_multi_entry_point(
     except Exception as ex:
         raise ErrorLoadingPlugin(entry_point=entry_point) from ex
 
-    for tool, schema in output.get("tools", {}).items():
+    for tool, schema in output["tools"].items():
         yield StoredPlugin(tool, schema)
     for schema in output.get("schemas", []):
         yield StoredPlugin("", schema)

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -66,7 +66,7 @@ class PluginWrapper:
 
 class StoredPlugin:
     def __init__(self, tool: str, schema: Schema):
-        self._tool = tool
+        self._tool, _, self._fragment = tool.partition("#")
         self._schema = schema
 
     @property
@@ -83,14 +83,17 @@ class StoredPlugin:
 
     @property
     def fragment(self) -> str:
-        return ""
+        return self._fragment
 
     @property
     def help_text(self) -> str:
         return self.schema.get("description", "")
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.tool!r}, <schema: {self.id}>)"
+        args = [repr(self.tool), self.id]
+        if self.fragment:
+            args.append(f"fragment={self.fragment!r}")
+        return f"{self.__class__.__name__}({', '.join(args)}, <schema: {self.id}>)"
 
 
 if typing.TYPE_CHECKING:

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -107,7 +107,7 @@ def iterate_entry_points(group: str) -> Iterable[EntryPoint]:
 
     This method can be used in conjunction with :obj:`load_from_entry_point` to filter
     the plugins before actually loading them. The entry points are not
-    deduplicated or sorted.
+    deduplicated.
     """
     entries = entry_points()
     if hasattr(entries, "select"):  # pragma: no cover
@@ -171,7 +171,11 @@ def list_from_entry_points(
     )
     multi_eps = (
         load_from_multi_entry_point(e)
-        for e in iterate_entry_points("validate_pyproject.multi_schema")
+        for e in sorted(
+            iterate_entry_points("validate_pyproject.multi_schema"),
+            key=lambda e: e.name,
+            reverse=True,
+        )
         if filtering(e)
     )
     eps: Iterable[Union[StoredPlugin, PluginWrapper]] = chain(

--- a/src/validate_pyproject/pre_compile/cli.py
+++ b/src/validate_pyproject/pre_compile/cli.py
@@ -7,10 +7,10 @@ import sys
 from functools import partial, wraps
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Dict, List, Mapping, NamedTuple, Sequence, Union
+from typing import Any, Dict, List, Mapping, NamedTuple, Sequence
 
 from .. import cli
-from ..plugins import PluginProtocol, PluginWrapper, StoredPlugin
+from ..plugins import PluginProtocol, PluginWrapper
 from ..plugins import list_from_entry_points as list_plugins_from_entry_points
 from ..remote import RemotePlugin, load_store
 from . import pre_compile
@@ -86,7 +86,7 @@ class CliParams(NamedTuple):
 
 
 def parser_spec(
-    plugins: Sequence[Union[PluginWrapper, StoredPlugin]],
+    plugins: Sequence[PluginProtocol],
 ) -> Dict[str, dict]:
     common = ("version", "enable", "disable", "verbose", "very_verbose")
     cli_spec = cli.__meta__(plugins)

--- a/src/validate_pyproject/pre_compile/cli.py
+++ b/src/validate_pyproject/pre_compile/cli.py
@@ -7,10 +7,10 @@ import sys
 from functools import partial, wraps
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Dict, List, Mapping, NamedTuple, Sequence
+from typing import Any, Dict, List, Mapping, NamedTuple, Sequence, Union
 
 from .. import cli
-from ..plugins import PluginProtocol, PluginWrapper
+from ..plugins import PluginProtocol, PluginWrapper, StoredPlugin
 from ..plugins import list_from_entry_points as list_plugins_from_entry_points
 from ..remote import RemotePlugin, load_store
 from . import pre_compile
@@ -85,7 +85,9 @@ class CliParams(NamedTuple):
     store: str = ""
 
 
-def parser_spec(plugins: Sequence[PluginWrapper]) -> Dict[str, dict]:
+def parser_spec(
+    plugins: Sequence[Union[PluginWrapper, StoredPlugin]],
+) -> Dict[str, dict]:
     common = ("version", "enable", "disable", "verbose", "very_verbose")
     cli_spec = cli.__meta__(plugins)
     meta = {k: v.copy() for k, v in META.items()}

--- a/src/validate_pyproject/repo_review.py
+++ b/src/validate_pyproject/repo_review.py
@@ -28,9 +28,9 @@ def repo_review_checks() -> Dict[str, VPP001]:
 
 def repo_review_families(pyproject: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
     has_distutils = "distutils" in pyproject.get("tool", {})
-    plugin_names = plugins.list_from_entry_points(
+    plugin_list = plugins.list_from_entry_points(
         lambda e: e.name != "distutils" or has_distutils
     )
-    plugin_list = (f"`[tool.{n}]`" for n in plugin_names)
-    descr = f"Checks `[build-system]`, `[project]`, {', '.join(plugin_list)}"
+    plugin_names = (f"`[tool.{n.tool}]`" for n in plugin_list if n.tool)
+    descr = f"Checks `[build-system]`, `[project]`, {', '.join(plugin_names)}"
     return {"validate-pyproject": {"name": "Validate-PyProject", "description": descr}}

--- a/src/validate_pyproject/repo_review.py
+++ b/src/validate_pyproject/repo_review.py
@@ -28,9 +28,9 @@ def repo_review_checks() -> Dict[str, VPP001]:
 
 def repo_review_families(pyproject: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
     has_distutils = "distutils" in pyproject.get("tool", {})
-    plugin_names = (ep.name for ep in plugins.iterate_entry_points())
-    plugin_list = (
-        f"`[tool.{n}]`" for n in plugin_names if n != "distutils" or has_distutils
+    plugin_names = plugins.list_from_entry_points(
+        lambda e: e.name != "distutils" or has_distutils
     )
+    plugin_list = (f"`[tool.{n}]`" for n in plugin_names)
     descr = f"Checks `[build-system]`, `[project]`, {', '.join(plugin_list)}"
     return {"validate-pyproject": {"name": "Validate-PyProject", "description": descr}}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,12 +1,15 @@
 # The code in this module is mostly borrowed/adapted from PyScaffold and was originally
 # published under the MIT license
 # The original PyScaffold license can be found in 'NOTICE.txt'
-from importlib.metadata import EntryPoint  # pragma: no cover
+import importlib.metadata
+import sys
+from types import ModuleType
+from typing import List
 
 import pytest
 
 from validate_pyproject import plugins
-from validate_pyproject.plugins import ENTRYPOINT_GROUP, ErrorLoadingPlugin
+from validate_pyproject.plugins import ErrorLoadingPlugin
 
 EXISTING = (
     "setuptools",
@@ -18,7 +21,9 @@ def test_load_from_entry_point__error():
     # This module does not exist, so Python will have some trouble loading it
     # EntryPoint(name, value, group)
     entry = "mypkg.SOOOOO___fake___:activate"
-    fake = EntryPoint("fake", entry, ENTRYPOINT_GROUP)
+    fake = importlib.metadata.EntryPoint(
+        "fake", entry, "validate_pyproject.tool_schema"
+    )
     with pytest.raises(ErrorLoadingPlugin):
         plugins.load_from_entry_point(fake)
 
@@ -28,7 +33,7 @@ def is_entry_point(ep):
 
 
 def test_iterate_entry_points():
-    plugin_iter = plugins.iterate_entry_points()
+    plugin_iter = plugins.iterate_entry_points("validate_pyproject.tool_schema")
     assert hasattr(plugin_iter, "__iter__")
     pluging_list = list(plugin_iter)
     assert all(is_entry_point(e) for e in pluging_list)
@@ -68,3 +73,31 @@ class TestPluginWrapper:
 
         pw = plugins.PluginWrapper("name", _fn2)
         assert pw.help_text == "Help for `name`"
+
+
+def fake_multi_iterate_entry_points(name: str) -> List[importlib.metadata.EntryPoint]:
+    if name == "validate_pyproject.multi_schema":
+        return [
+            importlib.metadata.EntryPoint(
+                name="_", value="test_module:f", group="validate_pyproject.multi_schema"
+            )
+        ]
+    return []
+
+
+def test_multi_plugins(monkeypatch):
+    s1 = {"id": "example1"}
+    s2 = {"id": "example2"}
+    s3 = {"id": "example3"}
+    sys.modules["test_module"] = ModuleType("test_module")
+    sys.modules["test_module"].f = lambda: {
+        "tools": {"example": s1},
+        "schemas": [s2, s3],
+    }  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        plugins, "iterate_entry_points", fake_multi_iterate_entry_points
+    )
+
+    lst = plugins.list_from_entry_points()
+    assert len(lst) == 3
+    assert all(e.id.startswith("example") for e in lst)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -91,7 +91,7 @@ def test_multi_plugins(monkeypatch):
     s3 = {"id": "example3"}
     sys.modules["test_module"] = ModuleType("test_module")
     sys.modules["test_module"].f = lambda: {
-        "tools": {"example": s1},
+        "tools": {"example#frag": s1},
         "schemas": [s2, s3],
     }  # type: ignore[attr-defined]
     monkeypatch.setattr(
@@ -101,3 +101,8 @@ def test_multi_plugins(monkeypatch):
     lst = plugins.list_from_entry_points()
     assert len(lst) == 3
     assert all(e.id.startswith("example") for e in lst)
+
+    (fragmented,) = (e for e in lst if e.tool)
+    assert fragmented.tool == "example"
+    assert fragmented.fragment == "frag"
+    assert fragmented.schema == s1


### PR DESCRIPTION
This closes #144 and closes #134, using the "That is a good approach!" approach. :)

This adds a new entry point, `validate_pyproject.multi_schema`, that returns a dictionary with `tools` as well as extra `schemas`. We could later add more optional keys to this dict, so it's flexible, and the `tools` table allows fragments to be specified. This would allow validate-pyproject-schema-store to return all of it's known schemas in one entry point, rather than having to add an entry point for every table (and would allow the extra schemas to finally be present).

A few points for review:

* Check to make sure names are reasonable, I didn't think too long and hard about names.
* Should `tools` be a required key (currently not)? (Someone could always add an empty dict if they specified the rest with classic entry points)
* Should one of the two take priority over the other? For back-compat, validate-pyproject-schema-store will likely provide both for a while. Currently this is just de-duped based on either the tool name, if present, or the schema ID otherwise, and multi plugins are loaded afterwards, so I think they take priority, but I could switch it (and test it).
* Should filtering be any different?
* I'm pulling help text from the description


