### PR TITLE
CI: Update GHA to use `uvx` + `tox-uv`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       - uses: actions/setup-python@v5
         with: {python-version: "3.10"}
       - uses: astral-sh/setup-uv@v5
-        with: {enable-cache: true}
       - name: Run static analysis and format checkers
         run: >-
           uvx --with tox-uv
@@ -84,7 +83,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - uses: astral-sh/setup-uv@v5
-        with: {enable-cache: true}
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v4
         with: {name: python-distribution-files, path: dist/}
@@ -128,7 +126,6 @@ jobs:
       - uses: actions/setup-python@v5
         with: {python-version: "3.10"}
       - uses: astral-sh/setup-uv@v5
-        with: {enable-cache: true}
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v4
         with: {name: python-distribution-files, path: dist/}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,19 +33,15 @@ jobs:
       - uses: actions/checkout@v4
         with: {fetch-depth: 0}  # deep clone for setuptools-scm
       - uses: actions/setup-python@v5
-        id: python-install
         with: {python-version: "3.10"}
+      - uses: astral-sh/setup-uv@v5
       - name: Run static analysis and format checkers
         run: >-
-          pipx run
-          --pip-args tox-uv
-          --python ${{ steps.python-install.outputs.python-path }}
+          uvx --with tox-uv
           tox -e lint,typecheck
       - name: Build package distribution files
         run: >-
-          pipx run
-          --pip-args tox-uv
-          --python ${{ steps.python-install.outputs.python-path }}
+          uvx --with tox-uv
           tox -e clean,build
       - name: Record the path of wheel distribution
         id: wheel-distribution
@@ -84,9 +80,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        id: python-install
         with:
           python-version: ${{ matrix.python }}
+      - uses: astral-sh/setup-uv@v5
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v4
         with: {name: python-distribution-files, path: dist/}
@@ -97,9 +93,7 @@ jobs:
           path: ${{ env.VALIDATE_PYPROJECT_CACHE_REMOTE }}
       - name: Run tests
         run: >-
-          pipx run
-          --pip-args tox-uv
-          --python ${{ steps.python-install.outputs.python-path }}
+          uvx --with tox-uv
           tox
           --installpkg '${{ needs.prepare.outputs.wheel-distribution }}'
           -- -n 5 -rFEx --durations 10 --color yes
@@ -131,6 +125,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with: {python-version: "3.10"}
+      - uses: astral-sh/setup-uv@v5
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v4
         with: {name: python-distribution-files, path: dist/}
@@ -141,7 +136,5 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: >-
-          pipx run
-          --pip-args tox-uv
-          --python ${{ steps.python-install.outputs.python-path }}
+          uvx --with tox-uv
           tox -e publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/setup-python@v5
         with: {python-version: "3.10"}
       - uses: astral-sh/setup-uv@v5
+        with: {enable-cache: true}
       - name: Run static analysis and format checkers
         run: >-
           uvx --with tox-uv
@@ -83,6 +84,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - uses: astral-sh/setup-uv@v5
+        with: {enable-cache: true}
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v4
         with: {name: python-distribution-files, path: dist/}
@@ -126,6 +128,7 @@ jobs:
       - uses: actions/setup-python@v5
         with: {python-version: "3.10"}
       - uses: astral-sh/setup-uv@v5
+        with: {enable-cache: true}
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v4
         with: {name: python-distribution-files, path: dist/}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,20 @@ jobs:
       - uses: actions/checkout@v4
         with: {fetch-depth: 0}  # deep clone for setuptools-scm
       - uses: actions/setup-python@v5
+        id: python-install
         with: {python-version: "3.10"}
       - name: Run static analysis and format checkers
-        run: pipx run --python python3.10 tox -e lint,typecheck
+        run: >-
+          pipx run
+          --pip-args tox-uv
+          --python ${{ steps.python-install.outputs.python-path }}
+          tox -e lint,typecheck
       - name: Build package distribution files
-        run: pipx run --python python3.10 tox -e clean,build
+        run: >-
+          pipx run
+          --pip-args tox-uv
+          --python ${{ steps.python-install.outputs.python-path }}
+          tox -e clean,build
       - name: Record the path of wheel distribution
         id: wheel-distribution
         run: echo "path=$(ls dist/*.whl)" >> $GITHUB_OUTPUT
@@ -75,6 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        id: python-install
         with:
           python-version: ${{ matrix.python }}
       - name: Retrieve pre-built distribution files
@@ -87,7 +97,10 @@ jobs:
           path: ${{ env.VALIDATE_PYPROJECT_CACHE_REMOTE }}
       - name: Run tests
         run: >-
-          pipx run tox
+          pipx run
+          --pip-args tox-uv
+          --python ${{ steps.python-install.outputs.python-path }}
+          tox
           --installpkg '${{ needs.prepare.outputs.wheel-distribution }}'
           -- -n 5 -rFEx --durations 10 --color yes
       - name: Generate coverage report
@@ -127,4 +140,8 @@ jobs:
           TWINE_REPOSITORY: pypi
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: pipx run tox -e publish
+        run: >-
+          pipx run
+          --pip-args tox-uv
+          --python ${{ steps.python-install.outputs.python-path }}
+          tox -e publish


### PR DESCRIPTION
The "explicit Python path" may not be necessary all the time, I did out of bad past experience with other Python's being picked up... (It is more verbose though...)

The `tox-uv` part is a follow up to include the same improvements as fond in https://github.com/abravalheri/validate-pyproject/pull/227