### PR TITLE
fix: priority is more important than plugin name

### DIFF
--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -165,10 +165,10 @@ class _SortablePlugin(NamedTuple):
     plugin: Union[PluginWrapper, StoredPlugin]
 
     def __lt__(self, other: Any) -> bool:
-        return (self.plugin.tool or self.plugin.id, self.name, self.priority) < (
+        return (self.plugin.tool or self.plugin.id, self.priority, self.name) < (
             other.plugin.tool or other.plugin.id,
-            other.name,
             other.priority,
+            other.name,
         )
 
 
@@ -184,12 +184,12 @@ def list_from_entry_points(
             plugin should be included.
     """
     tool_eps = (
-        _SortablePlugin(0, e.name, load_from_entry_point(e))
+        _SortablePlugin(1, e.name, load_from_entry_point(e))
         for e in iterate_entry_points("validate_pyproject.tool_schema")
         if filtering(e)
     )
     multi_eps = (
-        _SortablePlugin(1, e.name, p)
+        _SortablePlugin(0, e.name, p)
         for e in sorted(
             iterate_entry_points("validate_pyproject.multi_schema"),
             key=lambda e: e.name,


### PR DESCRIPTION
Issue mentioned in #240.

After this:

```
[INFO] https://json.schemastore.org/partial-black.json defines `tool.black` schema
[INFO] https://json.schemastore.org/partial-cibuildwheel.json defines `tool.cibuildwheel` schema
[INFO] validate_pyproject.api.load_builtin_plugin defines `tool.distutils` schema
[INFO] https://json.schemastore.org/hatch.json defines `tool.hatch` schema
[INFO] Extra schema: https://json.schemastore.org/partial-pdm-dockerize.json
[INFO] https://json.schemastore.org/maturin.json defines `tool.maturin` schema
[INFO] https://json.schemastore.org/partial-mypy.json defines `tool.mypy` schema
[INFO] https://json.schemastore.org/partial-pdm.json defines `tool.pdm` schema
[INFO] https://json.schemastore.org/partial-poe.json defines `tool.poe` schema
[INFO] https://json.schemastore.org/partial-poetry.json defines `tool.poetry` schema
[INFO] https://json.schemastore.org/partial-pyright.json defines `tool.pyright` schema
[INFO] https://json.schemastore.org/partial-repo-review.json defines `tool.repo-review` schema
[INFO] https://json.schemastore.org/ruff.json defines `tool.ruff` schema
[INFO] https://json.schemastore.org/partial-scikit-build.json defines `tool.scikit-build` schema
[INFO] https://json.schemastore.org/partial-setuptools.json defines `tool.setuptools` schema
[INFO] https://json.schemastore.org/partial-setuptools-scm.json defines `tool.setuptools_scm` schema
[INFO] https://json.schemastore.org/partial-taskipy.json defines `tool.taskipy` schema
[INFO] https://json.schemastore.org/tombi.json defines `tool.tombi` schema
[INFO] https://json.schemastore.org/partial-tox.json defines `tool.tox` schema
[INFO] https://json.schemastore.org/uv.json defines `tool.uv` schema
Valid file: pyproject.toml
```