### PR TITLE
Proposal: Alternative plugin sorting

### DIFF
--- a/docs/dev-guide.rst
+++ b/docs/dev-guide.rst
@@ -118,14 +118,11 @@ When using a :pep:`621`-compliant backend, the following can be add to your
 The plugin function will be automatically called with the ``tool_name``
 argument as same name as given to the entrypoint (e.g. :samp:`your_plugin({"your-tool"})`).
 
-Also notice plugins are activated in a specific order, using Python's built-in
-``sorted`` function.
-
 
 Providing multiple schemas
 --------------------------
 
-A second system is provided for providing multiple schemas in a single plugin.
+A second system is defined for providing multiple schemas in a single plugin.
 This is useful when a single plugin is responsible for multiple subtables
 under the ``tool`` table, or if you need to provide multiple schemas for a
 a single subtable.
@@ -157,6 +154,27 @@ An example of the plugin structure needed for this system is shown below:
 
 Fragments for schemas are also supported with this system; use ``#`` to split
 the tool name and fragment path in the dictionary key.
+
+
+.. admonition:: Experimental: Conflict Resolution
+
+   Please notice that when two plugins define the same ``tool``
+   (or auxiliary schemas with the same ``$id``),
+   an internal conflict resolution heuristic is employed to decide
+   which schema will take effect.
+
+   To influence this heuristic you can:
+
+   - Define a numeric ``.priority`` property in the functions
+     pointed by the ``validate_pyproject.tool_schema`` entry-points.
+   - Add a ``"priority"`` key with a numeric value into the dictionary
+     returned by the ``validate_pyproject.multi_schema`` plugins.
+
+   Typical values for ``priority`` are ``0`` and ``1``.
+
+   The exact order in which the plugins are loaded is considered an
+   implementation detail.
+
 
 .. _entry-point: https://setuptools.pypa.io/en/stable/userguide/entry_point.html#entry-points
 .. _JSON Schema: https://json-schema.org/

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -173,10 +173,10 @@ class _SortablePlugin(NamedTuple):
     plugin: Union[PluginWrapper, StoredPlugin]
 
     def __lt__(self, other: Any) -> bool:
-        return (self.plugin.tool or self.plugin.id, self.name, self.priority) < (
+        return (self.plugin.tool or self.plugin.id, self.priority, self.name) < (
             other.plugin.tool or other.plugin.id,
-            other.name,
             other.priority,
+            other.name,
         )
 
 
@@ -192,12 +192,12 @@ def list_from_entry_points(
             plugin should be included.
     """
     tool_eps = (
-        _SortablePlugin(0, e.name, load_from_entry_point(e))
+        _SortablePlugin(1, e.name, load_from_entry_point(e))
         for e in iterate_entry_points("validate_pyproject.tool_schema")
         if filtering(e)
     )
     multi_eps = (
-        _SortablePlugin(1, e.name, p)
+        _SortablePlugin(0, e.name, p)
         for e in sorted(
             iterate_entry_points("validate_pyproject.multi_schema"),
             key=lambda e: e.name,

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -45,9 +45,6 @@ class PluginProtocol(Protocol):
     @property
     def fragment(self) -> str: ...
 
-    @property
-    def priority(self) -> float: ...
-
 
 class PluginWrapper:
     def __init__(self, tool: str, load_fn: Plugin):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -198,7 +198,7 @@ def test_several_multi_plugins(monkeypatch):
     )
     for eps in (fake_eps, fake_eps.reverse()):
         monkeypatch.setattr(plugins, "iterate_entry_points", eps.get)
-        # "alphabetically higher" entry-point names have priority
+        # entry-point names closer to "zzzzzzzz..." have priority
         (plugin1, plugin2) = plugins.list_from_entry_points()
         assert plugin1.schema["$id"] == "example1"
         assert plugin2.schema["$id"] == "example3"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -124,11 +124,15 @@ def test_multi_plugins(monkeypatch):
     assert fragmented.schema == s1
 
 
-def fake_both_iterate_entry_points(name: str) -> List[importlib.metadata.EntryPoint]:
+def fake_both_iterate_entry_points(
+    name: str, epname: str
+) -> List[importlib.metadata.EntryPoint]:
     if name == "validate_pyproject.multi_schema":
         return [
             importlib.metadata.EntryPoint(
-                name="_", value="test_module:f", group="validate_pyproject.multi_schema"
+                name=epname,
+                value="test_module:f",
+                group="validate_pyproject.multi_schema",
             )
         ]
     if name == "validate_pyproject.tool_schema":
@@ -143,23 +147,35 @@ def fake_both_iterate_entry_points(name: str) -> List[importlib.metadata.EntryPo
                 value="test_module:f3",
                 group="validate_pyproject.tool_schema",
             ),
+            importlib.metadata.EntryPoint(
+                name="example4",
+                value="test_module:f4",
+                group="validate_pyproject.tool_schema",
+            ),
         ]
     return []
 
 
-def test_combined_plugins(monkeypatch):
+@pytest.mark.parametrize("epname", ["aaa", "zzz"])
+def test_combined_plugins(monkeypatch, epname):
     s1 = {"$id": "example1"}
     s2 = {"$id": "example2"}
+    s3 = {"$id": "example3"}
     sys.modules["test_module"] = ModuleType("test_module")
     sys.modules["test_module"].f = lambda: {
-        "tools": {"example1": s1, "example2": s2},
+        "tools": {"example1": s1, "example2": s2, "example3": s3},
     }  # type: ignore[attr-defined]
-    sys.modules["test_module"].f1 = lambda _: {"$id": "tool1"}  # type: ignore[attr-defined]
-    sys.modules["test_module"].f3 = lambda _: {"$id": "tool3"}  # type: ignore[attr-defined]
-    monkeypatch.setattr(plugins, "iterate_entry_points", fake_both_iterate_entry_points)
+    sys.modules["test_module"].f1 = lambda _: {"$id": "ztool1"}  # type: ignore[attr-defined]
+    sys.modules["test_module"].f3 = lambda _: {"$id": "atool3"}  # type: ignore[attr-defined]
+    sys.modules["test_module"].f4 = lambda _: {"$id": "tool4"}  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        plugins,
+        "iterate_entry_points",
+        functools.partial(fake_both_iterate_entry_points, epname=epname),
+    )
 
     lst = plugins.list_from_entry_points()
-    assert len(lst) == 3
+    assert len(lst) == 4
 
     assert lst[0].tool == "example1"
     assert isinstance(lst[0], StoredPlugin)
@@ -168,7 +184,10 @@ def test_combined_plugins(monkeypatch):
     assert isinstance(lst[1], StoredPlugin)
 
     assert lst[2].tool == "example3"
-    assert isinstance(lst[2], PluginWrapper)
+    assert isinstance(lst[2], StoredPlugin)
+
+    assert lst[3].tool == "example4"
+    assert isinstance(lst[3], PluginWrapper)
 
 
 def fake_several_entry_points(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -143,13 +143,13 @@ def fake_both_iterate_entry_points(
                 group="validate_pyproject.tool_schema",
             ),
             importlib.metadata.EntryPoint(
-                name="example3",
-                value="test_module:f3",
+                name="example2",
+                value="test_module:f2",
                 group="validate_pyproject.tool_schema",
             ),
             importlib.metadata.EntryPoint(
-                name="example4",
-                value="test_module:f4",
+                name="example3",
+                value="test_module:f3",
                 group="validate_pyproject.tool_schema",
             ),
         ]
@@ -160,14 +160,14 @@ def fake_both_iterate_entry_points(
 def test_combined_plugins(monkeypatch, epname):
     s1 = {"$id": "example1"}
     s2 = {"$id": "example2"}
-    s3 = {"$id": "example3"}
+    s4 = {"$id": "example3"}
     sys.modules["test_module"] = ModuleType("test_module")
     sys.modules["test_module"].f = lambda: {
-        "tools": {"example1": s1, "example2": s2, "example3": s3},
+        "tools": {"example1": s1, "example2": s2, "example4": s4},
     }  # type: ignore[attr-defined]
     sys.modules["test_module"].f1 = lambda _: {"$id": "ztool1"}  # type: ignore[attr-defined]
-    sys.modules["test_module"].f3 = lambda _: {"$id": "atool3"}  # type: ignore[attr-defined]
-    sys.modules["test_module"].f4 = lambda _: {"$id": "tool4"}  # type: ignore[attr-defined]
+    sys.modules["test_module"].f2 = lambda _: {"$id": "atool2"}  # type: ignore[attr-defined]
+    sys.modules["test_module"].f3 = lambda _: {"$id": "tool3"}  # type: ignore[attr-defined]
     monkeypatch.setattr(
         plugins,
         "iterate_entry_points",
@@ -184,10 +184,10 @@ def test_combined_plugins(monkeypatch, epname):
     assert isinstance(lst[1], StoredPlugin)
 
     assert lst[2].tool == "example3"
-    assert isinstance(lst[2], StoredPlugin)
+    assert isinstance(lst[2], PluginWrapper)
 
     assert lst[3].tool == "example4"
-    assert isinstance(lst[3], PluginWrapper)
+    assert isinstance(lst[3], StoredPlugin)
 
 
 def fake_several_entry_points(
@@ -196,12 +196,12 @@ def fake_several_entry_points(
     if name == "validate_pyproject.multi_schema":
         items = [
             importlib.metadata.EntryPoint(
-                name="a",
+                name="zzz",
                 value="test_module:f1",
                 group="validate_pyproject.multi_schema",
             ),
             importlib.metadata.EntryPoint(
-                name="b",
+                name="aaa",
                 value="test_module:f2",
                 group="validate_pyproject.multi_schema",
             ),
@@ -228,6 +228,7 @@ def test_several_multi_plugins(monkeypatch, reverse):
         functools.partial(fake_several_entry_points, reverse=reverse),
     )
 
+    # "alphabetically higher" entry-point names have priority
     (plugin1, plugin2) = plugins.list_from_entry_points()
     assert plugin1.schema["$id"] == "example1"
     assert plugin2.schema["$id"] == "example3"


### PR DESCRIPTION
Alternative to #242.

I am assuming the following:

- Plugins can be listed in any order, we just need this order to be consistent/reproducible.
  - All schemas/tools that are returned by `list_from_entry_points` end up loaded in the registry, independently of the order in the list.
  - There is no duplicates defining the same schemas/tools, because we remove them.
- We do need to stablish some sort of `priority/precedence` that tells us which plugin "wins" if multiple plugins specifies the same schema/tool.
  - Again the specific choice of how the priorities are assigned is not important, what is important is the consistence/reproducibility.

Therefore, I think the following would be fine:

- tool plugins are listed first than other schemas,
- multi plugins always have higher priority, so they can overwrite tool schemas previously loaded.
- the closer to "zzzzzzz..." is an entry-point name, the higher is the priority (inside the same entry-point group).

In practice this equates the sorted index to the priority in overwriting -- i.e. the higher indexes in the list overwrite the lower ones -- which matches very well dict-comprehensions.

With this in mind, this PR proposes one core change:
- d5ca823bb550a19a5cf92524e35c784dfb00a92f: Simplify the ordering in `list_from_entry_points` (avoids calling `sorted` multiple times, avoids `[::-1]`, avoids reversing).

... plus an auxiliary change that adds a helper to the tests:
- 4388d04: it took me some while to get my head around the order of the entrypoints in the tests, so I wanted to have visibility of them directly on the test function body to facilitate reasoning


Closes #242 