### PR TITLE
Allow package-data for stubs packages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
    Development Version
    ====================
 
+* Added support for specifying package-data for stub packages, #248.
+
 
 Version 0.24.1
 ==============

--- a/src/validate_pyproject/plugins/setuptools.schema.json
+++ b/src/validate_pyproject/plugins/setuptools.schema.json
@@ -116,7 +116,11 @@
       "type": "object",
       "additionalProperties": false,
       "propertyNames": {
-        "anyOf": [{"type": "string", "format": "python-module-name"}, {"const": "*"}]
+        "anyOf": [
+          {"type": "string", "format": "python-module-name"},
+          {"type": "string", "format": "pep561-stub-name"},
+          {"const": "*"}
+      ]
       },
       "patternProperties": {
         "^.*$": {"type": "array", "items": {"type": "string"}}
@@ -140,7 +144,11 @@
       "type": "object",
       "additionalProperties": false,
       "propertyNames": {
-        "anyOf": [{"type": "string", "format": "python-module-name"}, {"const": "*"}]
+        "anyOf": [
+          {"type": "string", "format": "python-module-name"},
+          {"type": "string", "format": "pep561-stub-name"},
+          {"const": "*"}
+        ]
       },
       "patternProperties": {
           "^.*$": {"type": "array", "items": {"type": "string"}}

--- a/tests/examples/setuptools/08-pyproject.toml
+++ b/tests/examples/setuptools/08-pyproject.toml
@@ -16,3 +16,7 @@ packages = ["mypkg-stubs"]
 
 [tool.setuptools.package-data]
 "*" = ["*.pyi"]
+"mypkg-stubs" = ["METADATA.toml"]
+
+[tool.setuptools.exclude-package-data]
+"mypkg-stubs" = ["*.rst"]


### PR DESCRIPTION
I'm currently working on moving the `stubs_uploader` from `setup.py` to `pyproject.toml`. _It's used to build and upload the typeshed stubs packages automatically._ While doing so I noticed that `setuptools` rejects stub package names like `requests-stubs` for `package-data`. I know that `.pyi` and `py.typed` files are auto-included. Each stubs package also contains a `METADATA.toml` file which should be included in the distribution. Do to the nature of the project, it would be desirable to use `include-package-data = false` and instead specify the wanted files directly.

This PR slightly modifies the schema to allow for that. _If accepted, it would be great if a new version could be released so I include these changes in setuptools._


https://github.com/typeshed-internal/stub_uploader/blob/cbdc0b85972e476b4dedbd626cd12dadf7dd60a9/stub_uploader/build_wheel.py#L51-L84