### PR TITLE
Update example from pdm-backend.

### DIFF
--- a/tests/examples/pdm/pyproject.toml
+++ b/tests/examples/pdm/pyproject.toml
@@ -1,205 +1,138 @@
 [project]
 # PEP 621 project metadata
-# See https://peps.python.org/pep-0621/
+# https://www.python.org/dev/peps/pep-0621
+name = "pdm-backend"
+description = "The build backend used by PDM that supports latest packaging standards"
 authors = [
-    {name = "frostming", email = "mianghong@gmail.com"},
+  { name = "Frost Ming", email = "me@frostming.com" }
 ]
-dynamic = ["version"]  # , "classifiers"]  ->  invalid CANNOT provide static and dynamic classifiers
-# version = {use_scm = true}  ->  invalid, must be string
-requires-python = ">=3.7"
 license = {text = "MIT"}
-dependencies = [
-    "appdirs",
-    "atoml>=1.0.3",
-    "click>=7",
-    "importlib-metadata; python_version < \"3.8\"",
-    "installer~=0.3.0",
-    "packaging",
-    "pdm-pep517>=0.8.3,<0.9",
-    "pep517>=0.11.0",
-    "pip>=20.1",
-    "python-dotenv~=0.15",
-    "pythonfinder",
-    "resolvelib>=0.7.0,<0.8.0",
-    "shellingham<2.0.0,>=1.3.2",
-    "tomli>=1.1.0,<2.0.0",
-    "typing-extensions; python_version < \"3.8\"",
-    "wheel<1.0.0,>=0.36.2",
-]
-name = "pdm"
-description = "Python Development Master"
+requires-python = ">=3.9"
 readme = "README.md"
-keywords = ["packaging", "dependency", "workflow"]
+keywords = ["packaging", "PEP 517", "build"]
+dynamic = ["version"]
+
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Topic :: Software Development :: Build Tools",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+
+dependencies = [
+    "importlib-metadata>=3.6; python_version < \"3.10\""
 ]
 
 [project.urls]
-homepage = "https://pdm.fming.dev"
-Repository = "https://github.com/pdm-project/pdm"
-Documentation = "https://pdm.fming.dev"
-
-[project.optional-dependencies]
-
-[project.scripts]
-pdm = "pdm.core:main"
-
-[tool.pdm]
-includes = ["pdm"]
-source-includes = ["tests"]
-# editables backend doesn't work well with namespace packages
-editable-backend = "path"
-
-[tool.pdm.scripts]
-release = "python tasks/release.py"
-test = "pytest tests/"
-doc = {shell = "cd docs && mkdocs serve", help = "Start the dev server for doc preview"}
-lint = "pre-commit run --all-files"
-complete = {call = "tasks.complete:main"}
-
-[tool.pdm.dev-dependencies]
-test = [
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-    "pytest-xdist<2.0.0,>=1.31.0"
-]
-doc = [
-    "mkdocs<2.0.0,>=1.1",
-    "mkdocs-material<7.0.0,>=6.2.4",
-    "markdown-include<1.0.0,>=0.5.1"
-]
-workflow = [
-    "parver<1.0.0,>=0.3.1",
-    "towncrier<20.0.0,>=19.2.0",
-    "vendoring; python_version ~= \"3.8\"",
-    "mypy~=0.812",
-    "pycomplete~=0.3"
-]
-
-[tool.black]
-line-length = 88
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-  | pdm/_vendor
-  | tests/fixtures
-)/
-'''
-
-[tool.towncrier]
-package = "pdm"
-filename = "CHANGELOG.md"
-issue_format = "[#{issue}](https://github.com/pdm-project/pdm/issues/{issue})"
-directory = "news/"
-title_format = "Release v{version} ({project_date})"
-template = "news/towncrier_template.md"
-underlines = "-~^"
-
-  [[tool.towncrier.type]]
-  directory = "feature"
-  name = "Features & Improvements"
-  showcontent = true
-
-  [[tool.towncrier.type]]
-  directory = "bugfix"
-  name = "Bug Fixes"
-  showcontent = true
-
-  [[tool.towncrier.type]]
-  directory = "doc"
-  name = "Improved Documentation"
-  showcontent = true
-
-  [[tool.towncrier.type]]
-  directory = "dep"
-  name = "Dependencies"
-  showcontent = true
-
-  [[tool.towncrier.type]]
-  directory = "removal"
-  name = "Removals and Deprecations"
-  showcontent = true
-
-  [[tool.towncrier.type]]
-  directory = "misc"
-  name = "Miscellany"
-  showcontent = true
-
-  [[tool.towncrier.type]]
-  directory = "refactor"
-  name = "Refactor"
-  showcontent = true
+Homepage = "https://github.com/pdm-project/pdm-backend"
+Repository = "https://github.com/pdm-project/pdm-backend"
+Documentation = "https://backend.pdm-project.org"
 
 [build-system]
-requires = ["pdm-pep517>=0.3.0"]
-build-backend = "pdm.pep517.api"
+requires = []
+build-backend = "pdm.backend.intree"
+backend-path = ["src"]
 
-[tool.isort]
-profile = "black"
-atomic = true
-skip_glob = ["*/setup.py", "pdm/_vendor/*"]
-filter_files = true
-known_first_party = ["pdm"]
-known_third_party = [
-    "appdirs",
-    "atoml",
-    "click",
-    "cfonts",
-    "distlib",
-    "halo",
-    "packaging",
-    "pip_shims",
-    "pytest",
-    "pythonfinder"
+[tool.ruff]
+src = ["src"]
+target-version = "py38"
+exclude = ["tests/fixtures"]
+
+[tool.ruff.lint]
+extend-select = [
+  "I",    # isort
+  "C4",   # flake8-comprehensions
+  "W",    # pycodestyle
+  "YTT",  # flake8-2020
+  "UP",   # pyupgrade
+  "FA",   # flake8-annotations
 ]
 
-[tool.vendoring]
-destination = "pdm/_vendor/"
-requirements = "pdm/_vendor/vendors.txt"
-namespace = "pdm._vendor"
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
-protected-files = ["__init__.py", "README.md", "vendors.txt"]
-patches-dir = "tasks/patches"
+[tool.ruff.lint.isort]
+known-first-party = ["pdm.backend"]
+
+[tool.vendoring]
+destination = "src/pdm/backend/_vendor/"
+requirements = "src/pdm/backend/_vendor/vendor.txt"
+namespace = "pdm.backend._vendor"
+patches-dir = "scripts/patches"
+protected-files = ["__init__.py", "README.md", "vendor.txt"]
 
 [tool.vendoring.transformations]
 substitute = [
-  {match = 'import halo\.', replace = 'import pdm._vendor.halo.'}
+    {match = "import packaging", replace = "import pdm.backend._vendor.packaging"},
 ]
 drop = [
     "bin/",
     "*.so",
     "typing.*",
-    "*/tests/"
+    "*/tests/",
+    "**/test_*.py",
+    "**/*_test.py"
 ]
 
-[tool.vendoring.typing-stubs]
-halo = []
-log_symbols = []
-spinners = []
-termcolor = []
-colorama = []
+[tool.pdm.version]
+source = "scm"
 
-[tool.vendoring.license.directories]
+[tool.pdm.build]
+includes = ["src"]
+package-dir = "src"
+source-includes = ["tests"]
 
-[tool.vendoring.license.fallback-urls]
-
-[tool.pytest.ini_options]
-filterwarnings = [
-  "ignore::DeprecationWarning"
+[tool.pdm.dev-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+    "pytest-gitconfig",
+    "pytest-xdist",
+    "setuptools",
 ]
-markers = [
-    "pypi: Tests that connect to the real PyPI",
-    "integration: Run with all Python versions"
+
+dev = [
+    "editables>=0.3",
+    "pre-commit>=2.21.0",
+    "vendoring>=1.2.0; python_version ~= \"3.8\"",
 ]
-addopts = "-ra"
+docs = [
+    "mkdocs>=1.4.2",
+    "mkdocstrings[python]>=0.19.0",
+    "mkdocs-material>=8.5.10",
+    "mkdocs-version-annotations>=1.0.0",
+]
+
+[tool.pdm.scripts]
+build = "python scripts/build.py"
+docs = "mkdocs serve"
+test = "pytest"
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "if self.debug",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]
+ignore_errors = true
+
+[tool.mypy]
+ignore_missing_imports = true
+disallow_incomplete_defs = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_untyped_decorators = true
+explicit_package_bases = true
+namespace_packages = true
+
+[[tool.mypy.overrides]]
+module = "pdm.backend._vendor.*"
+ignore_errors = true

--- a/tests/examples/pdm/test_config.json
+++ b/tests/examples/pdm/test_config.json
@@ -1,0 +1,6 @@
+{
+    "tools": {
+        "partial-pdm": "https://json.schemastore.org/partial-pdm.json",
+        "partial-pdm-dockerize": "https://json.schemastore.org/partial-pdm-dockerize.json"
+    }
+}


### PR DESCRIPTION
The old example for pyproject.toml from pdm-backend had a section which is no longer valid:
```
[tool.pdm]
includes = ["pdm"]
source-includes = ["tests"]
```

The new format is:
```
[tool.pdm.build]
includes = ["src"]
source-includes = ["tests"]
```

For some context, I am prototyping a [TOML schema](https://github.com/udifuchs/toml-schema). For testing, I converted the full pyproject JSON schema to a TOML schema, and I am using your test examples for testing the TOML schema. This is how I noticed this issue.

 