### PR TITLE
pre-commit-autoupdate-2025-07-03

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,10 @@ repos:
     args: [-w, -L, "THIRDPARTY"]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.10  # Ruff version
+  rev: v0.12.1  # Ruff version
   hooks:
-  - id: ruff
-    args: [--fix, --show-fixes]
+  - id: ruff-check
+    args: [--fix, --show-fixes, --ignore=PLC0415, --target-version=py310]
   - id: ruff-format
 
 - repo: https://github.com/adamchainz/blacken-docs
@@ -63,7 +63,7 @@ repos:
       - validate-pyproject[all]>=0.13
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.33.0
+  rev: 0.33.1
   hooks:
     - id: check-metaschema
       files: \.schema\.json$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,90 +1,83 @@
 [build-system]
-requires = ["setuptools>=61.2", "setuptools_scm[toml]>=7.1"]
 build-backend = "setuptools.build_meta"
+
+requires = [ "setuptools>=61.2", "setuptools-scm[toml]>=7.1" ]
 
 [project]
 name = "validate-pyproject"
 description = "Validation library and CLI tool for checking on 'pyproject.toml' files using JSON Schema"
-authors = [{name = "Anderson Bravalheri", email = "andersonbravalheri@gmail.com"}]
-readme ="README.rst"
-license = {text = "MPL-2.0 and MIT and BSD-3-Clause"}
-requires-python = ">=3.8"
+readme = "README.rst"
+license = { text = "MPL-2.0 and MIT and BSD-3-Clause" }
+authors = [ { name = "Anderson Bravalheri", email = "andersonbravalheri@gmail.com" } ]
+requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Developers",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Topic :: Software Development :: Quality Assurance",
-    "Typing :: Typed",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Quality Assurance",
+  "Typing :: Typed",
 ]
-dependencies = ["fastjsonschema>=2.16.2,<=3"]
-dynamic = ["version"]
+dynamic = [ "version" ]
 
-[project.urls]
-Homepage = "https://github.com/abravalheri/validate-pyproject/"
-Documentation = "https://validate-pyproject.readthedocs.io/"
-Source = "https://github.com/abravalheri/validate-pyproject"
-Tracker = "https://github.com/abravalheri/validate-pyproject/issues"
-Changelog = "https://validate-pyproject.readthedocs.io/en/latest/changelog.html"
-Download = "https://pypi.org/project/validate-pyproject/#files"
-
-[project.optional-dependencies]
-all = [
-    "packaging>=24.2",
-    "tomli>=1.2.1; python_version<'3.11'",
-    "trove-classifiers>=2021.10.20",
+dependencies = [ "fastjsonschema>=2.16.2,<=3" ]
+optional-dependencies.all = [
+  "packaging>=24.2",
+  "tomli>=1.2.1; python_version<'3.11'",
+  "trove-classifiers>=2021.10.20",
 ]
-store = ["validate-pyproject-schema-store"]
-
-[project.scripts]
-validate-pyproject = "validate_pyproject.cli:main"
-
-[project.entry-points."validate_pyproject.tool_schema"]
-setuptools = "validate_pyproject.api:load_builtin_plugin"
-distutils = "validate_pyproject.api:load_builtin_plugin"
-
-[project.entry-points."repo_review.checks"]
-validate_pyproject = "validate_pyproject.repo_review:repo_review_checks"
-
-[project.entry-points."repo_review.families"]
-validate_pyproject = "validate_pyproject.repo_review:repo_review_families"
+optional-dependencies.store = [ "validate-pyproject-schema-store" ]
+urls.Changelog = "https://validate-pyproject.readthedocs.io/en/latest/changelog.html"
+urls.Documentation = "https://validate-pyproject.readthedocs.io/"
+urls.Download = "https://pypi.org/project/validate-pyproject/#files"
+urls.Homepage = "https://github.com/abravalheri/validate-pyproject/"
+urls.Source = "https://github.com/abravalheri/validate-pyproject"
+urls.Tracker = "https://github.com/abravalheri/validate-pyproject/issues"
+scripts.validate-pyproject = "validate_pyproject.cli:main"
+entry-points."repo_review.checks".validate_pyproject = "validate_pyproject.repo_review:repo_review_checks"
+entry-points."repo_review.families".validate_pyproject = "validate_pyproject.repo_review:repo_review_families"
+entry-points."validate_pyproject.tool_schema".distutils = "validate_pyproject.api:load_builtin_plugin"
+entry-points."validate_pyproject.tool_schema".setuptools = "validate_pyproject.api:load_builtin_plugin"
 
 [dependency-groups]
 dev = [
-    { include-group = "test" },
-]
-docs = [
-    "furo>=2023.08.17",
-    "sphinx>=7.2.2",
-    "sphinx-argparse>=0.3.1",
-    "sphinx-copybutton",
-    "sphinx-jsonschema>=1.16.11",
-    "sphinxemoji",
+  { include-group = "test" },
 ]
 test = [
-    "setuptools",
-    "pytest>=8.3.3",
-    "pytest-cov",
-    "pytest-xdist",
-    "pytest-randomly",
-    "repo-review; python_version>='3.10'",
-    "tomli>=1.2.1; python_version<'3.11'",
+  "pytest>=8.3.3",
+  "pytest-cov",
+  "pytest-randomly",
+  "pytest-xdist",
+  "repo-review; python_version>='3.10'",
+  "setuptools",
+  "tomli>=1.2.1; python_version<'3.11'",
+]
+docs = [
+  "furo>=2023.8.17",
+  "sphinx>=7.2.2",
+  "sphinx-argparse>=0.3.1",
+  "sphinx-copybutton",
+  "sphinx-jsonschema>=1.16.11",
+  "sphinxemoji",
 ]
 typecheck = [
-    "mypy",
-    "importlib-resources",
-]
-
-[tool.uv]
-environments = [
-  "python_version >= '3.9'",
-]
-dev-dependencies = [
-  "validate_pyproject[all]",
+  "importlib-resources",
+  "mypy",
 ]
 
 [tool.setuptools_scm]
 version_scheme = "no-guess-dev"
+
+[tool.ruff]
+lint.ignore = [ "PLC0415" ]
+
+[tool.repo-review]
+ignore = [ "PP302", "PP304", "PP305", "PP306", "PP308", "PP309", "PC140", "PC180", "PC901" ]
 
 [tool.pytest.ini_options]
 addopts = """
@@ -95,13 +88,13 @@ addopts = """
     --strict-markers
     --verbose
 """
-norecursedirs = ["dist", "build", ".*"]
-testpaths = ["src", "tests"]
+norecursedirs = [ "dist", "build", ".*" ]
+testpaths = [ "src", "tests" ]
 log_cli_level = "info"
 
 [tool.mypy]
-python_version = "3.8"
-enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+python_version = "3.10"
+enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]
 show_traceback = true
 warn_unreachable = true
 strict = true
@@ -110,8 +103,13 @@ disallow_any_generics = false
 disallow_subclassing_any = false
 
 [[tool.mypy.overrides]]
-module = ["fastjsonschema", "setuptools._vendor.packaging"]
+module = [ "fastjsonschema", "setuptools._vendor.packaging" ]
 ignore_missing_imports = true
 
-[tool.repo-review]
-ignore = ["PP302", "PP304", "PP305", "PP306", "PP308", "PP309", "PC140", "PC180", "PC901"]
+[tool.uv]
+environments = [
+  "python_version >= '3.10'",
+]
+dev-dependencies = [
+  "validate_pyproject[all]",
+]

--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -6,19 +6,12 @@ import json
 import logging
 import sys
 import typing
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from enum import Enum
 from functools import partial, reduce
 from types import MappingProxyType, ModuleType
 from typing import (
-    Callable,
-    Dict,
-    Iterator,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
     TypeVar,
-    Union,
 )
 
 import fastjsonschema as FJS
@@ -37,7 +30,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 if sys.version_info >= (3, 9):  # pragma: no cover
     from importlib.resources import files
 
-    def read_text(package: Union[str, ModuleType], resource: str) -> str:
+    def read_text(package: str | ModuleType, resource: str) -> str:
         """:meta private:"""
         return files(package).joinpath(resource).read_text(encoding="utf-8")
 
@@ -95,7 +88,7 @@ class SchemaRegistry(Mapping[str, Schema]):
     """
 
     def __init__(self, plugins: Sequence["PluginProtocol"] = ()):
-        self._schemas: Dict[str, Tuple[str, str, Schema]] = {}
+        self._schemas: dict[str, tuple[str, str, Schema]] = {}
         # (which part of the TOML, who defines, schema)
 
         top_level = typing.cast("dict", load(TOP_LEVEL_SCHEMA))  # Make it mutable
@@ -114,7 +107,7 @@ class SchemaRegistry(Mapping[str, Schema]):
         # Add tools using Plugins
         for plugin in plugins:
             if plugin.tool:
-                allow_overwrite: Optional[str] = None
+                allow_overwrite: str | None = None
                 if plugin.tool in tool_properties:
                     _logger.warning(f"{plugin} overwrites `tool.{plugin.tool}` schema")
                     allow_overwrite = plugin.schema.get("$id")
@@ -150,7 +143,7 @@ class SchemaRegistry(Mapping[str, Schema]):
         self,
         reference: str,
         schema: Schema,
-        allow_overwrite: Optional[str] = None,
+        allow_overwrite: str | None = None,
     ) -> Schema:
         if "$id" not in schema or not schema["$id"]:
             raise errors.SchemaMissingId(reference or "<extra>")
@@ -212,15 +205,15 @@ class Validator:
 
     def __init__(
         self,
-        plugins: Union[Sequence["PluginProtocol"], AllPlugins] = ALL_PLUGINS,
+        plugins: Sequence["PluginProtocol"] | AllPlugins = ALL_PLUGINS,
         format_validators: Mapping[str, FormatValidationFn] = FORMAT_FUNCTIONS,
         extra_validations: Sequence[ValidationFn] = EXTRA_VALIDATIONS,
         *,
         extra_plugins: Sequence["PluginProtocol"] = (),
     ):
-        self._code_cache: Optional[str] = None
-        self._cache: Optional[ValidationFn] = None
-        self._schema: Optional[Schema] = None
+        self._code_cache: str | None = None
+        self._cache: ValidationFn | None = None
+        self._schema: Schema | None = None
 
         # Let's make the following options readonly
         self._format_validators = MappingProxyType(format_validators)

--- a/src/validate_pyproject/caching.py
+++ b/src/validate_pyproject/caching.py
@@ -4,8 +4,9 @@ import hashlib
 import io
 import logging
 import os
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Optional, Union
+from typing import Union
 
 PathLike = Union[str, "os.PathLike[str]"]
 _logger = logging.getLogger(__name__)
@@ -14,8 +15,8 @@ _logger = logging.getLogger(__name__)
 def as_file(
     fn: Callable[[str], io.StringIO],
     arg: str,
-    cache_dir: Optional[PathLike] = None,
-) -> Union[io.StringIO, io.BufferedReader]:
+    cache_dir: PathLike | None = None,
+) -> io.StringIO | io.BufferedReader:
     """
     Cache the result of calling ``fn(arg)`` into a file inside ``cache_dir``.
     The file name is derived from ``arg``.
@@ -36,7 +37,7 @@ def as_file(
     return open(cache_path, "rb")
 
 
-def path_for(arbitrary_id: str, cache: Optional[PathLike] = None) -> Optional[Path]:
+def path_for(arbitrary_id: str, cache: PathLike | None = None) -> Path | None:
     cache_dir = cache or os.getenv("VALIDATE_PYPROJECT_CACHE_REMOTE")
     if not cache_dir:
         return None

--- a/src/validate_pyproject/cli.py
+++ b/src/validate_pyproject/cli.py
@@ -10,19 +10,12 @@ import io
 import json
 import logging
 import sys
+from collections.abc import Callable, Generator, Iterator, Sequence
 from contextlib import contextmanager
 from itertools import chain
 from textwrap import dedent, wrap
 from typing import (
-    Callable,
-    Dict,
-    Generator,
-    Iterator,
-    List,
     NamedTuple,
-    Sequence,
-    Tuple,
-    Type,
     TypeVar,
 )
 
@@ -53,7 +46,7 @@ def critical_logging() -> Generator[None, None, None]:
 
 _STDIN = argparse.FileType("r")("-")
 
-META: Dict[str, dict] = {
+META: dict[str, dict] = {
     "version": dict(
         flags=("-V", "--version"),
         action="version",
@@ -116,15 +109,15 @@ META: Dict[str, dict] = {
 
 
 class CliParams(NamedTuple):
-    input_file: List[io.TextIOBase]
-    plugins: List[PluginWrapper]
-    tool: List[str]
+    input_file: list[io.TextIOBase]
+    plugins: list[PluginWrapper]
+    tool: list[str]
     store: str
     loglevel: int = logging.WARNING
     dump_json: bool = False
 
 
-def __meta__(plugins: Sequence[PluginProtocol]) -> Dict[str, dict]:
+def __meta__(plugins: Sequence[PluginProtocol]) -> dict[str, dict]:
     """'Hyper parameters' to instruct :mod:`argparse` how to create the CLI"""
     meta = {k: v.copy() for k, v in META.items()}
     meta["enable"]["choices"] = {p.tool for p in plugins}
@@ -137,8 +130,8 @@ def parse_args(
     args: Sequence[str],
     plugins: Sequence[PluginProtocol],
     description: str = "Validate a given TOML file",
-    get_parser_spec: Callable[[Sequence[PluginProtocol]], Dict[str, dict]] = __meta__,
-    params_class: Type[T] = CliParams,  # type: ignore[assignment]
+    get_parser_spec: Callable[[Sequence[PluginProtocol]], dict[str, dict]] = __meta__,
+    params_class: type[T] = CliParams,  # type: ignore[assignment]
 ) -> T:
     """Parse command line parameters
 
@@ -174,7 +167,7 @@ def select_plugins(
     plugins: Sequence[Plugins],
     enabled: Sequence[str] = (),
     disabled: Sequence[str] = (),
-) -> List[Plugins]:
+) -> list[Plugins]:
     available = list(plugins)
     if enabled:
         available = [p for p in available if p.tool in enabled]
@@ -262,7 +255,7 @@ class Formatter(argparse.RawTextHelpFormatter):
     # order to create our own formatter, we are left no choice other then overwrite a
     # "private" method considered to be an implementation detail.
 
-    def _split_lines(self, text: str, width: int) -> List[str]:
+    def _split_lines(self, text: str, width: int) -> list[str]:
         return list(chain.from_iterable(wrap(x, width) for x in text.splitlines()))
 
 
@@ -289,7 +282,7 @@ def _format_file(file: io.TextIOBase) -> str:
 
 
 class _ExceptionGroup(Exception):
-    _members: List[Tuple[str, Exception]]
+    _members: list[tuple[str, Exception]]
 
     def __init__(self) -> None:
         self._members = []
@@ -298,7 +291,7 @@ class _ExceptionGroup(Exception):
     def add(self, prefix: str, ex: Exception) -> None:
         self._members.append((prefix, ex))
 
-    def __iter__(self) -> Iterator[Tuple[str, Exception]]:
+    def __iter__(self) -> Iterator[tuple[str, Exception]]:
         return iter(self._members)
 
     def raise_if_any(self) -> None:

--- a/src/validate_pyproject/extra_validations.py
+++ b/src/validate_pyproject/extra_validations.py
@@ -3,8 +3,9 @@ difficult to express as a JSON Schema (or that are not supported by the current
 JSON Schema library).
 """
 
+from collections.abc import Mapping
 from inspect import cleandoc
-from typing import Mapping, TypeVar
+from typing import TypeVar
 
 from .error_reporting import ValidationError
 

--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -16,7 +16,7 @@ import typing
 from itertools import chain as _chain
 
 if typing.TYPE_CHECKING:
-    from typing_extensions import Literal
+    from typing import Literal
 
 _logger = logging.getLogger(__name__)
 
@@ -163,7 +163,7 @@ class _TroveClassifier:
     option (classifiers will be validated anyway during the upload to PyPI).
     """
 
-    downloaded: typing.Union[None, "Literal[False]", typing.Set[str]]
+    downloaded: typing.Union[None, "Literal[False]", set[str]]
     """
     None => not cached yet
     False => unavailable

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -6,15 +6,13 @@
 """
 
 import typing
+from collections.abc import Callable, Generator, Iterable
 from importlib.metadata import EntryPoint, entry_points
 from itertools import chain
 from string import Template
 from textwrap import dedent
 from typing import (
     Any,
-    Callable,
-    Generator,
-    Iterable,
     List,
     NamedTuple,
     Optional,
@@ -182,7 +180,7 @@ def load_from_multi_entry_point(
 
 class _SortablePlugin(NamedTuple):
     name: str
-    plugin: Union[PluginWrapper, StoredPlugin]
+    plugin: PluginWrapper | StoredPlugin
 
     def key(self) -> str:
         return self.plugin.tool or self.plugin.id
@@ -208,7 +206,7 @@ class _SortablePlugin(NamedTuple):
 
 def list_from_entry_points(
     filtering: Callable[[EntryPoint], bool] = lambda _: True,
-) -> List[Union[PluginWrapper, StoredPlugin]]:
+) -> list[PluginWrapper | StoredPlugin]:
     """Produces a list of plugin objects for each plugin registered
     via ``setuptools`` `entry point`_ mechanism.
 
@@ -240,7 +238,7 @@ class ErrorLoadingPlugin(RuntimeError):
     """
     __doc__ = _DESC
 
-    def __init__(self, plugin: str = "", entry_point: Optional[EntryPoint] = None):
+    def __init__(self, plugin: str = "", entry_point: EntryPoint | None = None):
         if entry_point and not plugin:
             plugin = getattr(entry_point, "module", entry_point.name)
 

--- a/src/validate_pyproject/pre_compile/__init__.py
+++ b/src/validate_pyproject/pre_compile/__init__.py
@@ -1,9 +1,10 @@
 import logging
 import os
+from collections.abc import Mapping, Sequence
 from importlib import metadata as _M
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Dict, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import fastjsonschema as FJS
 
@@ -24,10 +25,10 @@ TEXT_REPLACEMENTS = MappingProxyType(
 
 
 def pre_compile(  # noqa: PLR0913
-    output_dir: Union[str, os.PathLike] = ".",
+    output_dir: str | os.PathLike = ".",
     main_file: str = "__init__.py",
     original_cmd: str = "",
-    plugins: Union[api.AllPlugins, Sequence["PluginProtocol"]] = api.ALL_PLUGINS,
+    plugins: api.AllPlugins | Sequence["PluginProtocol"] = api.ALL_PLUGINS,
     text_replacements: Mapping[str, str] = TEXT_REPLACEMENTS,
     *,
     extra_plugins: Sequence["PluginProtocol"] = (),
@@ -58,33 +59,33 @@ def pre_compile(  # noqa: PLR0913
     return out
 
 
-def replace_text(text: str, replacements: Dict[str, str]) -> str:
+def replace_text(text: str, replacements: dict[str, str]) -> str:
     for orig, subst in replacements.items():
         text = text.replace(orig, subst)
     return text
 
 
 def copy_fastjsonschema_exceptions(
-    output_dir: Path, replacements: Dict[str, str]
+    output_dir: Path, replacements: dict[str, str]
 ) -> Path:
     code = replace_text(api.read_text(FJS.__name__, "exceptions.py"), replacements)
     return _write(output_dir / "fastjsonschema_exceptions.py", code)
 
 
-def copy_module(name: str, output_dir: Path, replacements: Dict[str, str]) -> Path:
+def copy_module(name: str, output_dir: Path, replacements: dict[str, str]) -> Path:
     code = api.read_text(api.__package__, f"{name}.py")
     return _write(output_dir / f"{name}.py", replace_text(code, replacements))
 
 
 def write_main(
-    file_path: Path, schema: types.Schema, replacements: Dict[str, str]
+    file_path: Path, schema: types.Schema, replacements: dict[str, str]
 ) -> Path:
     code = api.read_text(__name__, "main_file.template")
     return _write(file_path, replace_text(code, replacements))
 
 
 def write_notice(
-    out: Path, main_file: str, cmd: str, replacements: Dict[str, str]
+    out: Path, main_file: str, cmd: str, replacements: dict[str, str]
 ) -> Path:
     if cmd:
         opening = api.read_text(__name__, "cli-notice.template")
@@ -98,7 +99,7 @@ def write_notice(
     return _write(out / "NOTICE", notice)
 
 
-def load_licenses() -> Dict[str, str]:
+def load_licenses() -> dict[str, str]:
     return {
         "fastjsonschema_license": _find_and_load_licence(_M.files("fastjsonschema")),
         "validate_pyproject_license": _find_and_load_licence(_M.files(dist_name)),
@@ -117,7 +118,7 @@ NOCHECK_HEADERS = (
 )
 
 
-def _find_and_load_licence(files: Optional[Sequence[_M.PackagePath]]) -> str:
+def _find_and_load_licence(files: Sequence[_M.PackagePath] | None) -> str:
     if files is None:  # pragma: no cover
         raise ImportError("Could not find LICENSE for package")
     try:

--- a/src/validate_pyproject/pre_compile/cli.py
+++ b/src/validate_pyproject/pre_compile/cli.py
@@ -4,10 +4,11 @@
 import json
 import logging
 import sys
+from collections.abc import Mapping, Sequence
 from functools import partial, wraps
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Dict, List, Mapping, NamedTuple, Sequence
+from typing import Any, NamedTuple
 
 from .. import cli
 from ..plugins import PluginProtocol, PluginWrapper
@@ -24,14 +25,14 @@ else:  # pragma: no cover
 _logger = logging.getLogger(__package__)
 
 
-def JSON_dict(name: str, value: str) -> Dict[str, Any]:
+def JSON_dict(name: str, value: str) -> dict[str, Any]:
     try:
         return ensure_dict(name, json.loads(value))
     except json.JSONDecodeError as ex:
         raise ValueError(f"Invalid JSON: {value}") from ex
 
 
-META: Dict[str, dict] = {
+META: dict[str, dict] = {
     "output_dir": dict(
         flags=("-O", "--output-dir"),
         default=".",
@@ -76,7 +77,7 @@ def ensure_dict(name: str, value: Any) -> dict:
 
 
 class CliParams(NamedTuple):
-    plugins: List[PluginWrapper]
+    plugins: list[PluginWrapper]
     output_dir: Path = Path(".")
     main_file: str = "__init__.py"
     replacements: Mapping[str, str] = MappingProxyType({})
@@ -87,7 +88,7 @@ class CliParams(NamedTuple):
 
 def parser_spec(
     plugins: Sequence[PluginProtocol],
-) -> Dict[str, dict]:
+) -> dict[str, dict]:
     common = ("version", "enable", "disable", "verbose", "very_verbose")
     cli_spec = cli.__meta__(plugins)
     meta = {k: v.copy() for k, v in META.items()}
@@ -103,7 +104,7 @@ def run(args: Sequence[str] = ()) -> int:
     prms = cli.parse_args(args, plugins, desc, parser_spec, CliParams)
     cli.setup_logging(prms.loglevel)
 
-    tool_plugins: List[PluginProtocol] = [RemotePlugin.from_str(t) for t in prms.tool]
+    tool_plugins: list[PluginProtocol] = [RemotePlugin.from_str(t) for t in prms.tool]
     if prms.store:
         tool_plugins.extend(load_store(prms.store))
 

--- a/src/validate_pyproject/remote.py
+++ b/src/validate_pyproject/remote.py
@@ -2,7 +2,7 @@ import json
 import logging
 import typing
 import urllib.parse
-from typing import Generator, Optional, Tuple
+from collections.abc import Generator
 
 from . import caching, errors, http
 from .types import Schema
@@ -23,8 +23,8 @@ _logger = logging.getLogger(__name__)
 
 
 def load_from_uri(
-    tool_uri: str, cache_dir: Optional[caching.PathLike] = None
-) -> Tuple[str, Schema]:
+    tool_uri: str, cache_dir: caching.PathLike | None = None
+) -> tuple[str, Schema]:
     tool_info = urllib.parse.urlparse(tool_uri)
     if tool_info.netloc:
         url = f"{tool_info.scheme}://{tool_info.netloc}{tool_info.path}"

--- a/src/validate_pyproject/repo_review.py
+++ b/src/validate_pyproject/repo_review.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import fastjsonschema
 
@@ -13,7 +13,7 @@ class VPP001:
     family = "validate-pyproject"
 
     @staticmethod
-    def check(pyproject: Dict[str, Any]) -> str:
+    def check(pyproject: dict[str, Any]) -> str:
         validator = api.Validator()
         try:
             validator(pyproject)
@@ -22,11 +22,11 @@ class VPP001:
             return f"Invalid pyproject.toml! Error: {e}"
 
 
-def repo_review_checks() -> Dict[str, VPP001]:
+def repo_review_checks() -> dict[str, VPP001]:
     return {"VPP001": VPP001()}
 
 
-def repo_review_families(pyproject: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
+def repo_review_families(pyproject: dict[str, Any]) -> dict[str, dict[str, str]]:
     has_distutils = "distutils" in pyproject.get("tool", {})
     plugin_list = plugins.list_from_entry_points(
         lambda e: e.name != "distutils" or has_distutils

--- a/src/validate_pyproject/types.py
+++ b/src/validate_pyproject/types.py
@@ -1,4 +1,5 @@
-from typing import Callable, Mapping, NewType, TypeVar
+from collections.abc import Callable, Mapping
+from typing import NewType, TypeVar
 
 T = TypeVar("T", bound=Mapping)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ Read more about conftest.py under:
 """
 
 from pathlib import Path
-from typing import List
 
 import pytest
 
@@ -18,7 +17,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "uses_network: tests may try to download files")
 
 
-def collect(base: Path) -> List[str]:
+def collect(base: Path) -> list[str]:
     return [str(f.relative_to(base)) for f in base.glob("**/*.toml")]
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,6 @@
 import functools
 import json
 from pathlib import Path
-from typing import Dict, List, Union
 
 from validate_pyproject.remote import RemotePlugin, load_store
 
@@ -16,7 +15,7 @@ def error_file(p: Path) -> Path:
         raise FileNotFoundError(f"No error file found for {p}") from None
 
 
-def get_test_config(example: Path) -> Dict[str, Union[str, Dict[str, str]]]:
+def get_test_config(example: Path) -> dict[str, str | dict[str, str]]:
     test_config = example.with_name("test_config.json")
     if test_config.is_file():
         with test_config.open(encoding="utf-8") as f:
@@ -24,10 +23,10 @@ def get_test_config(example: Path) -> Dict[str, Union[str, Dict[str, str]]]:
     return {}
 
 
-@functools.lru_cache(maxsize=None)
-def get_tools(example: Path) -> List[RemotePlugin]:
+@functools.cache
+def get_tools(example: Path) -> list[RemotePlugin]:
     config = get_test_config(example)
-    tools: Dict[str, str] = config.get("tools", {})
+    tools: dict[str, str] = config.get("tools", {})
     load_tools = [RemotePlugin.from_url(k, v) for k, v in tools.items()]
     store: str = config.get("store", "")
     if store:
@@ -35,10 +34,10 @@ def get_tools(example: Path) -> List[RemotePlugin]:
     return load_tools
 
 
-@functools.lru_cache(maxsize=None)
-def get_tools_as_args(example: Path) -> List[str]:
+@functools.cache
+def get_tools_as_args(example: Path) -> list[str]:
     config = get_test_config(example)
-    tools: Dict[str, str] = config.get("tools", {})
+    tools: dict[str, str] = config.get("tools", {})
     load_tools = [f"--tool={k}={v}" for k, v in tools.items()]
     store: str = config.get("store", "")
     if store:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -125,7 +125,7 @@ class TestValidator:
 
     TOOLS = ("distutils", "setuptools")
 
-    @pytest.mark.parametrize("tool, other_tool", zip(TOOLS, reversed(TOOLS)))
+    @pytest.mark.parametrize("tool, other_tool", zip(TOOLS, reversed(TOOLS), strict=True))
     def test_plugin_not_enabled(self, tool, other_tool):
         plg = self.plugin(tool)
         validator = api.Validator([plg])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -125,7 +125,9 @@ class TestValidator:
 
     TOOLS = ("distutils", "setuptools")
 
-    @pytest.mark.parametrize("tool, other_tool", zip(TOOLS, reversed(TOOLS), strict=True))
+    @pytest.mark.parametrize(
+        "tool, other_tool", zip(TOOLS, reversed(TOOLS), strict=True)
+    )
     def test_plugin_not_enabled(self, tool, other_tool):
         plg = self.plugin(tool)
         validator = api.Validator([plg])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,7 +103,9 @@ class TestEnable:
 class TestDisable:
     TOOLS = ("setuptools", "distutils")
 
-    @pytest.mark.parametrize("tool, other_tool", zip(TOOLS, reversed(TOOLS), strict=True))
+    @pytest.mark.parametrize(
+        "tool, other_tool", zip(TOOLS, reversed(TOOLS), strict=True)
+    )
     def test_parse(self, valid_example, tool, other_tool):
         all_plugins = parse_args([str(valid_example), "-D", tool]).plugins
         our_plugins = [p for p in all_plugins if p.id.startswith("validate_pyproject")]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,7 +103,7 @@ class TestEnable:
 class TestDisable:
     TOOLS = ("setuptools", "distutils")
 
-    @pytest.mark.parametrize("tool, other_tool", zip(TOOLS, reversed(TOOLS)))
+    @pytest.mark.parametrize("tool, other_tool", zip(TOOLS, reversed(TOOLS), strict=True))
     def test_parse(self, valid_example, tool, other_tool):
         all_plugins = parse_args([str(valid_example), "-D", tool]).plugins
         our_plugins = [p for p in all_plugins if p.id.startswith("validate_pyproject")]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 import sys
 from collections import defaultdict
+from collections.abc import Callable
 from importlib.metadata import EntryPoint
 from types import ModuleType
-from typing import Callable, TypeVar
+from typing import TypeVar
 
 import pytest
 


### PR DESCRIPTION
I don't think a `match` statement can be mixed with requires-python that is less than py3.10.

When we step up to py3.10 there are a bunch of new rules that ruff check wants to apply.

```
tools/to_schemastore.py:9:9: SyntaxError: Cannot use `match` statement on Python 3.8 (syntax was added in Python 3.10)
   |
 7 | def convert_tree(tree: dict[str, object]) -> None:
 8 |     for key, value in list(tree.items()):
 9 |         match key, value:
   |         ^^^^^
10 |             case "$$description", list():
11 |                 tree["description"] = " ".join(value)
   |
```

Also, added `uvx pyproject-fmt pyproject.toml`