### PR TITLE
Python 3.14 and pre-commit autoupdate

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -98,6 +98,8 @@ linux_task:
       skip: $BRANCH !=~ "^(main|master)$"
     - name: test (Linux - 3.13)
       container: {image: "python:3.13-bookworm"}
+    - name: test (Linux - 3.13)
+      container: {image: "python:3.13-trixie"}
     - name: test (Linux - 3.14)
       container: {image: "python:3.14-rc-bookworm"}
       allow_failures: true  # RC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v5
         with: {fetch-depth: 0}  # deep clone for setuptools-scm
       - uses: actions/setup-python@v6
-        with: {python-version: "3.10"}
+        with: {python-version: "3.x"}
       - uses: astral-sh/setup-uv@v6
       - name: Run static analysis and format checkers
         run: >-
@@ -55,7 +55,7 @@ jobs:
           path: dist/
           retention-days: 1
       - name: Download files used for testing
-        run: python3.10 tools/cache_urls_for_tests.py
+        run: python tools/cache_urls_for_tests.py
       - name: Store downloaded files
         uses: actions/upload-artifact@v4
         with:
@@ -72,9 +72,10 @@ jobs:
         python:
         - "3.8"   # oldest Python supported by validate-pyproject
         - "3.x"   # newest Python that is stable
+        - "3.14"
         platform:
         - ubuntu-latest
-        - macos-13
+        - macos-15-intel
         - windows-latest
     runs-on: ${{ matrix.platform }}
     steps:
@@ -82,6 +83,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - uses: astral-sh/setup-uv@v6
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v5
@@ -124,7 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
-        with: {python-version: "3.10"}
+        with: {python-version: "3.x"}
       - uses: astral-sh/setup-uv@v6
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^src/validate_pyproject/_vendor'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: check-added-large-files
   - id: check-ast
@@ -23,17 +23,17 @@ repos:
   rev: v2.4.1
   hooks:
   - id: codespell
-    args: [-w, -L, "THIRDPARTY"]
+    args: ["--ignore-words-list=THIRDPARTY", --write-changes]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.10  # Ruff version
+  rev: v0.13.2
   hooks:
-  - id: ruff
-    args: [--fix, --show-fixes]
+  - id: ruff-check
+    args: [--exclude=tools/to_schemastore.py, "--ignore=PLC0415,RUF200", --fix, --show-fixes, ]
   - id: ruff-format
 
 - repo: https://github.com/adamchainz/blacken-docs
-  rev: 1.19.1
+  rev: 1.20.0
   hooks:
   - id: blacken-docs
     additional_dependencies: [black==23.*]
@@ -63,7 +63,7 @@ repos:
       - validate-pyproject[all]>=0.13
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.33.0
+  rev: 0.34.0
   hooks:
     - id: check-metaschema
       files: \.schema\.json$

--- a/tests/examples/pdm/pyproject.toml
+++ b/tests/examples/pdm/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [


### PR DESCRIPTION
Python 3.14 is in one week.

Debian v13 "Trixie" was released on Aug. 9, 2025

Fixes:
* #257 

Upgrade from deprecated `macos-13` to `macos-15-intel`.

The currently available GitHub Actions macOS runners are:
| macOS Version | runner.arch |
|---------------|-------------|
| macos-13 | X64 |
| macos-14 | ARM64 |
| macos-15 | ARM64 |
| macos-15-intel | X64 |
| macos-26 | ARM64 |
| macos-latest | ARM64 |
* Let's prepare for actions/runner-images#13046