### PR TITLE
GitHub: macOS 13 hosted runner image is closing down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         - "3.x"   # newest Python that is stable
         platform:
         - ubuntu-latest
-        - macos-13
+        - macos-14
         - windows-latest
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/