### PR TITLE
fix: __package__ -> __spec__.parent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "tomli>=1.2.1; python_version<'3.11'",
 ]
 typecheck = [
-    "mypy",
+    "tomli>=1.2.1",
     "importlib-resources",
 ]
 
@@ -98,6 +98,7 @@ testpaths = ["src", "tests"]
 log_level = "INFO"
 
 [tool.mypy]
+files = "src"
 python_version = "3.9"
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 show_traceback = true
@@ -106,6 +107,8 @@ strict = true
 # Scaling back on some of the strictness for now
 disallow_any_generics = false
 disallow_subclassing_any = false
+show_error_context = true
+pretty = true
 
 [[tool.mypy.overrides]]
 module = ["fastjsonschema", "setuptools._vendor.packaging"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,6 @@ strict = true
 # Scaling back on some of the strictness for now
 disallow_any_generics = false
 disallow_subclassing_any = false
-show_error_context = true
-pretty = true
 
 [[tool.mypy.overrides]]
 module = ["fastjsonschema", "setuptools._vendor.packaging"]

--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -31,6 +31,9 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 __all__ = ["Validator"]
 
+assert __spec__ is not None
+assert __spec__.parent is not None
+PARENT = __spec__.parent
 
 T = TypeVar("T", bound=Mapping)
 AllPlugins = Enum("AllPlugins", "ALL_PLUGINS")  #: :meta private:
@@ -51,7 +54,7 @@ def _get_public_functions(module: ModuleType) -> Mapping[str, FormatValidationFn
 FORMAT_FUNCTIONS = MappingProxyType(_get_public_functions(formats))
 
 
-def load(name: str, package: str = __package__, ext: str = ".schema.json") -> Schema:
+def load(name: str, package: str = PARENT, ext: str = ".schema.json") -> Schema:
     """Load the schema from a JSON Schema file.
     The returned dict-like object is immutable.
 
@@ -62,7 +65,9 @@ def load(name: str, package: str = __package__, ext: str = ".schema.json") -> Sc
 
 def load_builtin_plugin(name: str) -> Schema:
     """:meta private: (low level detail)"""
-    return load(name, f"{__package__}.plugins")
+    assert __spec__ is not None
+    assert __spec__.parent is not None
+    return load(name, f"{__spec__.parent}.plugins")
 
 
 class SchemaRegistry(Mapping[str, Schema]):

--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -33,7 +33,7 @@ __all__ = ["Validator"]
 
 assert __spec__ is not None
 assert __spec__.parent is not None
-PARENT = __spec__.parent
+_PARENT = __spec__.parent
 
 T = TypeVar("T", bound=Mapping)
 AllPlugins = Enum("AllPlugins", "ALL_PLUGINS")  #: :meta private:
@@ -54,7 +54,7 @@ def _get_public_functions(module: ModuleType) -> Mapping[str, FormatValidationFn
 FORMAT_FUNCTIONS = MappingProxyType(_get_public_functions(formats))
 
 
-def load(name: str, package: str = PARENT, ext: str = ".schema.json") -> Schema:
+def load(name: str, package: str = _PARENT, ext: str = ".schema.json") -> Schema:
     """Load the schema from a JSON Schema file.
     The returned dict-like object is immutable.
 
@@ -65,9 +65,7 @@ def load(name: str, package: str = PARENT, ext: str = ".schema.json") -> Schema:
 
 def load_builtin_plugin(name: str) -> Schema:
     """:meta private: (low level detail)"""
-    assert __spec__ is not None
-    assert __spec__.parent is not None
-    return load(name, f"{__spec__.parent}.plugins")
+    return load(name, f"{_PARENT}.plugins")
 
 
 class SchemaRegistry(Mapping[str, Schema]):

--- a/src/validate_pyproject/cli.py
+++ b/src/validate_pyproject/cli.py
@@ -32,7 +32,10 @@ if TYPE_CHECKING:
     import io
     from collections.abc import Generator, Iterator, Sequence
 
-_logger = logging.getLogger(__package__)
+assert __spec__ is not None
+assert __spec__.parent is not None
+
+_logger = logging.getLogger(__spec__.parent)
 T = TypeVar("T", bound=NamedTuple)
 
 _REGULAR_EXCEPTIONS = (ValidationError, tomllib.TOMLDecodeError)
@@ -55,7 +58,7 @@ META: dict[str, dict] = {
     "version": dict(
         flags=("-V", "--version"),
         action="version",
-        version=f"{__package__} {__version__}",
+        version=f"{__spec__.parent} {__version__}",
     ),
     "input_file": dict(
         dest="input_file",

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -245,6 +245,8 @@ class ErrorLoadingPlugin(RuntimeError):
         if entry_point and not plugin:
             plugin = getattr(entry_point, "module", entry_point.name)
 
-        sub = {"package": __package__, "version": __version__, "plugin": plugin}
+        assert __spec__ is not None
+        assert __spec__.parent is not None
+        sub = {"package": __spec__.parent, "version": __version__, "plugin": plugin}
         msg = dedent(self._DESC).format(**sub).splitlines()
         super().__init__(f"{msg[0]}\n{' '.join(msg[1:])}")

--- a/src/validate_pyproject/pre_compile/__init__.py
+++ b/src/validate_pyproject/pre_compile/__init__.py
@@ -77,7 +77,9 @@ def copy_fastjsonschema_exceptions(
 
 
 def copy_module(name: str, output_dir: Path, replacements: dict[str, str]) -> Path:
-    code = _resources.read_text(api.__package__, f"{name}.py")
+    assert api.__spec__ is not None
+    assert api.__spec__.parent is not None
+    code = _resources.read_text(api.__spec__.parent, f"{name}.py")
     return _write(output_dir / f"{name}.py", replace_text(code, replacements))
 
 

--- a/src/validate_pyproject/pre_compile/cli.py
+++ b/src/validate_pyproject/pre_compile/cli.py
@@ -24,8 +24,10 @@ if sys.platform == "win32":  # pragma: no cover
 else:  # pragma: no cover
     from shlex import join as arg_join
 
+assert __spec__ is not None
+assert __spec__.parent is not None
 
-_logger = logging.getLogger(__package__)
+_logger = logging.getLogger(__spec__.parent)
 
 
 def JSON_dict(name: str, value: str) -> dict[str, Any]:
@@ -103,8 +105,11 @@ def parser_spec(
 
 
 def run(args: Sequence[str] = ()) -> int:
+    assert __spec__ is not None
+    assert __spec__.parent is not None
+
     args = args or sys.argv[1:]
-    cmd = f"python -m {__package__} " + arg_join(args)
+    cmd = f"python -m {__spec__.parent} " + arg_join(args)
     plugins = list_plugins_from_entry_points()
     desc = 'Generate files for "pre-compiling" `validate-pyproject`'
     prms = cli.parse_args(args, plugins, desc, parser_spec, CliParams)

--- a/src/validate_pyproject/pre_compile/cli.py
+++ b/src/validate_pyproject/pre_compile/cli.py
@@ -24,8 +24,10 @@ if sys.platform == "win32":  # pragma: no cover
 else:  # pragma: no cover
     from shlex import join as arg_join
 
+assert __spec__ is not None
+assert __spec__.parent is not None
 
-_logger = logging.getLogger(__package__)
+_logger = logging.getLogger(__spec__.parent)
 
 
 def JSON_dict(name: str, value: str) -> dict[str, Any]:
@@ -103,8 +105,11 @@ def parser_spec(
 
 
 def run(args: Sequence[str] = ()) -> int:
+    assert __spec__ is not None
+    assert __spec__.parent is not None
+
     args = args if args else sys.argv[1:]
-    cmd = f"python -m {__package__} " + arg_join(args)
+    cmd = f"python -m {__spec__.parent} " + arg_join(args)
     plugins = list_plugins_from_entry_points()
     desc = 'Generate files for "pre-compiling" `validate-pyproject`'
     prms = cli.parse_args(args, plugins, desc, parser_spec, CliParams)

--- a/src/validate_pyproject/pre_compile/cli.py
+++ b/src/validate_pyproject/pre_compile/cli.py
@@ -27,7 +27,8 @@ else:  # pragma: no cover
 assert __spec__ is not None
 assert __spec__.parent is not None
 
-_logger = logging.getLogger(__spec__.parent)
+_PARENT = __spec__.parent
+_logger = logging.getLogger(_PARENT)
 
 
 def JSON_dict(name: str, value: str) -> dict[str, Any]:
@@ -105,11 +106,8 @@ def parser_spec(
 
 
 def run(args: Sequence[str] = ()) -> int:
-    assert __spec__ is not None
-    assert __spec__.parent is not None
-
     args = args or sys.argv[1:]
-    cmd = f"python -m {__spec__.parent} " + arg_join(args)
+    cmd = f"python -m {_PARENT} " + arg_join(args)
     plugins = list_plugins_from_entry_points()
     desc = 'Generate files for "pre-compiling" `validate-pyproject`'
     prms = cli.parse_args(args, plugins, desc, parser_spec, CliParams)

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ commands =
 
 
 [testenv:typecheck]
-base_python = 3.9
 description = Invoke mypy to typecheck the source code
 changedir = {toxinidir}
 passenv =
@@ -44,8 +43,9 @@ passenv =
     # ^ ensure colors
 extras = all
 dependency_groups = typecheck
+deps = mypy
 commands =
-    python -m mypy {posargs:--pretty --show-error-context src}
+    mypy src
 
 
 [testenv:{build,clean}]

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ extras = all
 dependency_groups = typecheck
 deps = mypy
 commands =
-    mypy src
+    mypy {posargs:--pretty --show-error-context}
 
 
 [testenv:{build,clean}]


### PR DESCRIPTION
I was reworking the typing job a bit, mostly to try `ty`, and it noticed that we are using `__package__`, which is [scheduled for removal in 3.15](https://docs.python.org/3.15/reference/datamodel.html#module.__package__). I moved this over to the replacement. This includes the original restructuring to try out `ty`, which also removes the pin on Python. `tomli` has to be required unconditionally. And the typechecking tool is moved to the job, since you could be using a different tool (like `ty`).
