### PR TITLE
`__package__` → `__spec__.parent`

### DIFF
--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -51,7 +51,9 @@ def _get_public_functions(module: ModuleType) -> Mapping[str, FormatValidationFn
 FORMAT_FUNCTIONS = MappingProxyType(_get_public_functions(formats))
 
 
-def load(name: str, package: str = __spec__.parent, ext: str = ".schema.json") -> Schema:
+def load(
+    name: str, package: str = __spec__.parent, ext: str = ".schema.json"
+) -> Schema:
     """Load the schema from a JSON Schema file.
     The returned dict-like object is immutable.
 

--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -51,7 +51,7 @@ def _get_public_functions(module: ModuleType) -> Mapping[str, FormatValidationFn
 FORMAT_FUNCTIONS = MappingProxyType(_get_public_functions(formats))
 
 
-def load(name: str, package: str = __package__, ext: str = ".schema.json") -> Schema:
+def load(name: str, package: str = __spec__.parent, ext: str = ".schema.json") -> Schema:
     """Load the schema from a JSON Schema file.
     The returned dict-like object is immutable.
 
@@ -62,7 +62,7 @@ def load(name: str, package: str = __package__, ext: str = ".schema.json") -> Sc
 
 def load_builtin_plugin(name: str) -> Schema:
     """:meta private: (low level detail)"""
-    return load(name, f"{__package__}.plugins")
+    return load(name, f"{__spec__.parent}.plugins")
 
 
 class SchemaRegistry(Mapping[str, Schema]):

--- a/src/validate_pyproject/cli.py
+++ b/src/validate_pyproject/cli.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     import io
     from collections.abc import Generator, Iterator, Sequence
 
-_logger = logging.getLogger(__package__)
+_logger = logging.getLogger(__spec__.parent)
 T = TypeVar("T", bound=NamedTuple)
 
 _REGULAR_EXCEPTIONS = (ValidationError, tomllib.TOMLDecodeError)
@@ -55,7 +55,7 @@ META: dict[str, dict] = {
     "version": dict(
         flags=("-V", "--version"),
         action="version",
-        version=f"{__package__} {__version__}",
+        version=f"{__spec__.parent} {__version__}",
     ),
     "input_file": dict(
         dest="input_file",

--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -245,6 +245,6 @@ class ErrorLoadingPlugin(RuntimeError):
         if entry_point and not plugin:
             plugin = getattr(entry_point, "module", entry_point.name)
 
-        sub = {"package": __package__, "version": __version__, "plugin": plugin}
+        sub = {"package": __spec__.parent, "version": __version__, "plugin": plugin}
         msg = dedent(self._DESC).format(**sub).splitlines()
         super().__init__(f"{msg[0]}\n{' '.join(msg[1:])}")

--- a/src/validate_pyproject/pre_compile/__init__.py
+++ b/src/validate_pyproject/pre_compile/__init__.py
@@ -77,7 +77,7 @@ def copy_fastjsonschema_exceptions(
 
 
 def copy_module(name: str, output_dir: Path, replacements: dict[str, str]) -> Path:
-    code = _resources.read_text(api.__package__, f"{name}.py")
+    code = _resources.read_text(api.__spec__.parent, f"{name}.py")
     return _write(output_dir / f"{name}.py", replace_text(code, replacements))
 
 

--- a/src/validate_pyproject/pre_compile/cli.py
+++ b/src/validate_pyproject/pre_compile/cli.py
@@ -25,7 +25,7 @@ else:  # pragma: no cover
     from shlex import join as arg_join
 
 
-_logger = logging.getLogger(__package__)
+_logger = logging.getLogger(__spec__.parent)
 
 
 def JSON_dict(name: str, value: str) -> dict[str, Any]:
@@ -104,7 +104,7 @@ def parser_spec(
 
 def run(args: Sequence[str] = ()) -> int:
     args = args or sys.argv[1:]
-    cmd = f"python -m {__package__} " + arg_join(args)
+    cmd = f"python -m {__spec__.parent} {arg_join(args)}"
     plugins = list_plugins_from_entry_points()
     desc = 'Generate files for "pre-compiling" `validate-pyproject`'
     prms = cli.parse_args(args, plugins, desc, parser_spec, CliParams)


### PR DESCRIPTION
Remove deprecated `__package__`, scheduled for [removal in Python 3.15](https://docs.python.org/3.15/reference/datamodel.html#module.__package__).