### PR TITLE
fix: allow duplicated identical schemas

### DIFF
--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -140,7 +140,14 @@ class SchemaRegistry(Mapping[str, Schema]):
             raise errors.SchemaMissingId(reference or "<extra>")
         sid = schema["$id"]
         if sid in self._schemas and sid != allow_overwrite:
-            raise errors.SchemaWithDuplicatedId(sid)
+            existing = self._schemas[sid][-1]
+            if dict(existing) != dict(schema):
+                raise errors.SchemaWithDuplicatedId(sid)
+            _logger.warning(
+                f"Duplicate schema {sid!r} for `tool.{reference}` ignored "
+                "(same schema already registered)"
+            )
+            return existing
         version = schema.get("$schema")
         # Support schemas with missing trailing # (incorrect, but required before 0.15)
         if version and version.rstrip("#") != self.spec_version.rstrip("#"):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,6 +67,25 @@ class TestRegistry:
         schema = self.fake_plugin("plg")
         fn = wraps(self.fake_plugin)(lambda _: schema)  # Same ID
         plg = [plugins.PluginWrapper(f"plg{i}", fn) for i in range(2)]
+        # Same schema for different tools is allowed (e.g. aliases)
+        registry = api.SchemaRegistry(plg)
+        sid = schema["$id"]
+        assert sid in registry
+
+    def test_duplicated_id_different_tools__different_schema(self):
+        base = self.fake_plugin("plg")
+
+        def _make_schema(i):
+            s = dict(base)
+            s["description"] = f"schema {i}"
+            return types.Schema(s)
+
+        fn0 = wraps(self.fake_plugin)(lambda _: _make_schema(0))
+        fn1 = wraps(self.fake_plugin)(lambda _: _make_schema(1))
+        plg = [
+            plugins.PluginWrapper("plg0", fn0),
+            plugins.PluginWrapper("plg1", fn1),
+        ]
         with pytest.raises(errors.SchemaWithDuplicatedId):
             api.SchemaRegistry(plg)
 


### PR DESCRIPTION
SchemaStore now has the same schema for two different entries. This handles the latest SchemaStore.

The fix here lets you register matching IDs if the schemas also match exactly.

:robot: Assisted-by: Copilot:Kimi-K2.6
