### PR TITLE
tests: run in parallel via tox by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ passenv =
 dependency_groups = test
 extras = all
 commands =
-    pytest {posargs}
+    pytest -n auto {posargs}
 
 
 [testenv:lint]


### PR DESCRIPTION
Run in parallel by default. On my new mac with 18 cores, this is much faster.
