### PR TITLE
fix: support relative urls in SchemaStore

### DIFF
--- a/src/validate_pyproject/remote.py
+++ b/src/validate_pyproject/remote.py
@@ -79,13 +79,17 @@ def load_store(pyproject_url: str) -> Generator[RemotePlugin, None, None]:
             pass  # built-in
         elif "$ref" in info:
             _logger.info(f"Loading {tool} from store: {pyproject_url}")
-            rp = RemotePlugin.from_url(tool, info["$ref"])
+            rp = RemotePlugin.from_url(
+                tool, urllib.parse.urljoin(pyproject_url, info["$ref"])
+            )
             yield rp
             # Does not support anyOf and similar with properties inside them
             for values in rp.schema.get("properties", {}).values():
                 url = values.get("$ref", "")
-                if url.startswith(("https://", "https://")):
-                    yield RemotePlugin.from_url("", url)
+                if url:
+                    absolute_url = urllib.parse.urljoin(rp.id, url)
+                    if absolute_url.startswith(("http://", "https://")):
+                        yield RemotePlugin.from_url("", absolute_url)
         else:
             _logger.warning(f"{tool!r} does not contain $ref")  # pragma: no cover
 

--- a/tools/cache_urls_for_tests.py
+++ b/tools/cache_urls_for_tests.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import sys
+import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -16,13 +17,30 @@ from validate_pyproject import caching, http  # noqa: E402
 SCHEMA_STORE = "https://json.schemastore.org/pyproject.json"
 
 
+def _iter_nested_refs(base_url: str):
+    """Yield nested $ref URLs found inside a schema's properties."""
+    with caching.as_file(http.open_url, base_url) as f:
+        try:
+            schema = json.load(f)
+        except json.JSONDecodeError:
+            return
+    for values in schema.get("properties", {}).values():
+        ref_url = values.get("$ref", "")
+        if ref_url:
+            nested = urllib.parse.urljoin(base_url, ref_url)
+            if nested.startswith(("http://", "https://")):
+                yield nested
+
+
 def iter_test_urls():
     with caching.as_file(http.open_url, SCHEMA_STORE) as f:
         store = json.load(f)
         for tool in store["properties"]["tool"]["properties"].values():
-            if "$ref" in tool and tool["$ref"].startswith(("http://", "https://")):
-                yield tool["$ref"]
-
+            if "$ref" in tool:
+                url = urllib.parse.urljoin(SCHEMA_STORE, tool["$ref"])
+                if url.startswith(("http://", "https://")):
+                    yield url
+                    yield from _iter_nested_refs(url)
     files = PROJECT.glob("**/test_config.json")
     for file in files:
         content = json.loads(file.read_text("utf-8"))


### PR DESCRIPTION
CI is broken with the new relative URLs for SchemaStore, this adds support for those.


<details><summary>:robot: Summary</summary>
<p>

**Root cause**: SchemaStore's `pyproject.json` recently switched from absolute URLs to **relative `$ref` URLs** (e.g. `"$ref": "partial-black.json"`). The code was passing these directly to `load_from_uri`, which tried to open them as local files, causing `FileNotFoundError`.

1. **`src/validate_pyproject/remote.py`** — Resolve relative `$ref` URLs using `urllib.parse.urljoin`:
   - When loading tool schemas from the store, resolve `$ref` against the store URL.
   - When loading nested `$ref`s inside a schema's `properties`, resolve against the schema's `$id`.
   - Also fixed a typo in the protocol check (`("https://", "https://")` → `("http://", "https://")`).

2. **`tools/cache_urls_for_tests.py`** — Updated the cache script to:
   - Resolve relative `$ref`s against `SCHEMA_STORE`.
   - Recursively discover and download nested relative refs (so offline tests work too).

3. **Populated `tests/.cache/`** with all required schemas so the tests run offline.

</p>
</details> 



:robot: Assisted-by: OpenCode:Kimi-K2.6
