### PR TITLE
ci: reduce coveralls sensitivity

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -2,5 +2,3 @@
 # Reduces reporting sensitivity to minor coverage fluctuations
 # (0.1% shows up in CI on unrelated changes)
 allow-loss: 0.3
-
-

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,6 @@
+# Coveralls configuration
+# Reduces reporting sensitivity to minor coverage fluctuations
+# (0.1% shows up in CI on unrelated changes)
+allow-loss: 0.3
+
+


### PR DESCRIPTION
Coveralls is reporting PRs with no code changes as dropping by 0.1%. Let's reduce the sensitivity a little.
