### PR TITLE
fix: apply filtering before loading multi_schema entry points

### DIFF
--- a/src/validate_pyproject/plugins/__init__.py
+++ b/src/validate_pyproject/plugins/__init__.py
@@ -226,8 +226,8 @@ def list_from_entry_points(
     multi_eps = (
         _SortablePlugin(e.name, p)
         for e in iterate_entry_points("validate_pyproject.multi_schema")
-        for p in load_from_multi_entry_point(e)
         if filtering(e)
+        for p in load_from_multi_entry_point(e)
     )
     eps = chain(tool_eps, multi_eps)
     dedup = {e.key(): e.plugin for e in sorted(eps)}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -243,3 +243,27 @@ def test_broken_multi_plugin(monkeypatch):
     monkeypatch.setattr(plugins, "iterate_entry_points", fake_eps.get)
     with pytest.raises(ErrorLoadingPlugin):
         plugins.list_from_entry_points()
+
+
+def test_multi_plugin_filtering_prevents_load(monkeypatch):
+    """Filtering should prevent loading a multi_schema entry point entirely.
+
+    A broken excluded plugin must NOT raise ErrorLoadingPlugin — the filter
+    decision must be applied before ``load_from_multi_entry_point`` is called.
+    """
+    fake_eps = _FakeEntryPoints(monkeypatch, "validate_pyproject.multi_schema")
+
+    loaded = []
+    _msg = "should never be called"
+
+    def broken_multi():
+        loaded.append(True)
+        raise RuntimeError(_msg)
+
+    fake_eps(name="excluded", value="test_module:broken_multi")(broken_multi)
+    monkeypatch.setattr(plugins, "iterate_entry_points", fake_eps.get)
+
+    # filtering excludes the entry point — no error should be raised
+    result = plugins.list_from_entry_points(filtering=lambda e: e.name != "excluded")
+    assert result == []
+    assert loaded == [], "broken excluded plugin was loaded despite filtering"


### PR DESCRIPTION
I'm not totally sure I knew that you could do this (if guard in the middle)...

:robot: _AI text below_ :robot:

Addresses finding 4 of #317.

## Bug

In `list_from_entry_points` (`src/validate_pyproject/plugins/__init__.py`), the `multi_eps` generator had the `if filtering(e)` guard placed **after** the inner `for p in load_from_multi_entry_point(e)` clause:

```python
multi_eps = (
    _SortablePlugin(e.name, p)
    for e in iterate_entry_points("validate_pyproject.multi_schema")
    for p in load_from_multi_entry_point(e)   # ← entry point loaded here
    if filtering(e)                            # ← filter checked too late
)
```

This meant every `multi_schema` entry point was loaded and executed before the filter was consulted. A broken plugin excluded by `filtering` would still raise `ErrorLoadingPlugin`, contradicting the docstring which states filtering decides "if the entry point should be loaded". The `tool_eps` generator just above already got the order right.

## Fix

Move `if filtering(e)` to immediately after the outer `for e in ...` clause, before the inner `for p in load_from_multi_entry_point(e)`:

```python
multi_eps = (
    _SortablePlugin(e.name, p)
    for e in iterate_entry_points("validate_pyproject.multi_schema")
    if filtering(e)                            # ← filter checked first
    for p in load_from_multi_entry_point(e)   # ← only loaded if not filtered
)
```

## Regression test

`tests/test_plugins.py::test_multi_plugin_filtering_prevents_load` registers a fake `multi_schema` entry point whose load function raises, passes a `filtering` function that excludes it, and asserts that no `ErrorLoadingPlugin` is raised and the load function is never called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)