### PR TITLE
fix: add timeout to network requests

### DIFF
--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -153,9 +153,10 @@ def _download_classifiers() -> str:
     from email.message import Message
     from urllib.request import urlopen
 
+    _TIMEOUT = 10  # seconds; avoids hanging indefinitely in pre-commit hooks
     url = "https://pypi.org/pypi?:action=list_classifiers"
     context = ssl.create_default_context()
-    with urlopen(url, context=context) as response:  # noqa: S310 (audit URLs)
+    with urlopen(url, context=context, timeout=_TIMEOUT) as response:  # noqa: S310 (audit URLs)
         headers = Message()
         headers["content_type"] = response.getheader("content-type", "text/plain")
         return response.read().decode(headers.get_param("charset", "utf-8"))  # type: ignore[no-any-return]

--- a/src/validate_pyproject/http.py
+++ b/src/validate_pyproject/http.py
@@ -4,6 +4,8 @@ import io
 import sys
 from urllib.request import urlopen
 
+_TIMEOUT = 10  # seconds; avoids hanging indefinitely in pre-commit hooks
+
 if sys.platform == "emscripten" and "pyodide" in sys.modules:
     from pyodide.http import open_url
 else:
@@ -12,5 +14,5 @@ else:
         if not url.startswith(("http:", "https:")):
             msg = "URL must start with 'http:' or 'https:'"
             raise ValueError(msg)
-        with urlopen(url) as response:  # noqa: S310
+        with urlopen(url, timeout=_TIMEOUT) as response:  # noqa: S310
             return io.StringIO(response.read().decode("utf-8"))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses the network-timeout finding of #317.

## Summary

- Adds `timeout=10` to the `urlopen` call in `src/validate_pyproject/http.py` (`open_url`)
- Adds `timeout=10` to the `urlopen` call in `src/validate_pyproject/formats.py` (`_download_classifiers`)
- Uses a `_TIMEOUT = 10` constant in each location for clarity

Without a timeout, a stalled connection to PyPI or a remote schema host hangs the process indefinitely. This is especially problematic when `validate-pyproject` runs as a pre-commit hook, blocking a developer's commit with no way out except Ctrl-C.

`urllib`'s default timeout is the global socket timeout, which is typically `None` (no timeout).

**Note:** The 10-second value is a judgment call — reviewers may want to adjust it (e.g. to 30s for slow connections, or make it configurable via an env var).

## Test plan

- [ ] All existing tests pass (596 pass, 1 skipped; 2 `uses_network` classifier tests are pre-existing failures when network is blocked by `VALIDATE_PYPROJECT_NO_NETWORK=1`)
- [ ] No mocks of `urlopen` directly in tests — tests mock `http.open_url` at the module level, so the added kwarg does not affect them
- [ ] Lint (`prek -a --quiet`) passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)