### PR TITLE
fix: handle edge cases in format validators for import names and object references

### DIFF
--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -15,7 +15,6 @@ import os
 import re
 import string
 import typing
-from itertools import chain as _chain
 
 if typing.TYPE_CHECKING:
     import builtins
@@ -133,15 +132,25 @@ def pep508_versionspec(value: str) -> bool:
 # PEP 517
 
 
+def _is_dotted_identifier(value: str) -> bool:
+    """Every dot-separated segment of ``value`` must be a valid Python identifier
+    (and there must be at least one, i.e. ``value`` must be non-empty).
+    """
+    parts = value.split(".")
+    return all(python_identifier(part.strip()) for part in parts)
+
+
 def pep517_backend_reference(value: str) -> bool:
     """See PyPA's specification for defining build-backend references
     introduced in :pep:`517#source-trees`.
 
     This is similar to an entry-point reference (e.g., ``package.module:object``).
     """
-    module, _, obj = value.partition(":")
-    identifiers = (i.strip() for i in _chain(module.split("."), obj.split(".")))
-    return all(python_identifier(i) for i in identifiers if i)
+    module, sep, obj = value.partition(":")
+    if not _is_dotted_identifier(module):
+        return False
+    # If a separator is present, the object part must also be a valid dotted identifier
+    return _is_dotted_identifier(obj) if sep else True
 
 
 # -------------------------------------------------------------------------------------
@@ -349,10 +358,16 @@ def python_entrypoint_reference(value: str) -> bool:
     See ``Data model >object reference`` in the :ref:`PyPA's entry-points specification
     <pypa:entry-points>`.
     """
-    module, _, rest = value.partition(":")
+    module, sep, rest = value.partition(":")
+    if not _is_dotted_identifier(module):
+        return False
+    if not sep:
+        # No object reference: ``importable.module`` is sufficient.
+        return True
+
     if "[" in rest:
         obj, _, extras_ = rest.partition("[")
-        if extras_.strip()[-1] != "]":
+        if not extras_.strip().endswith("]"):
             return False
         extras = (x.strip() for x in extras_.strip(string.whitespace + "[]").split(","))
         if not all(pep508_identifier(e) for e in extras):
@@ -361,9 +376,8 @@ def python_entrypoint_reference(value: str) -> bool:
     else:
         obj = rest
 
-    module_parts = module.split(".")
-    identifiers = _chain(module_parts, obj.split(".")) if rest else iter(module_parts)
-    return all(python_identifier(i.strip()) for i in identifiers)
+    # A separator was present, so the object reference is required and must be valid.
+    return _is_dotted_identifier(obj)
 
 
 def uint8(value: builtins.int) -> bool:
@@ -443,7 +457,7 @@ except ImportError:  # pragma: no cover
 VALID_IMPORT_NAME = re.compile(
     r"""
     ^                                  # start of string
-        [A-Za-z_][A-Za-z_0-9]+         # a valid Python identifier
+        [A-Za-z_][A-Za-z_0-9]*         # a valid Python identifier
         (?:\.[A-Za-z_][A-Za-z_0-9]*)*  # optionally followed by .identifier's
     (?:\s*;\s*private)?                # optionally followed by ; private
     $                                  # end of string

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -145,6 +145,22 @@ def test_invalid_entrypoint_references(example):
     assert formats.python_entrypoint_reference(example) is result
 
 
+@pytest.mark.parametrize("example", ["mod:obj[", "module:"])
+def test_malformed_entrypoint_references(example):
+    # Should return False instead of raising an exception
+    assert formats.python_entrypoint_reference(example) is False
+
+
+@pytest.mark.parametrize("example", ["", ":attr", "module:", "a..b:c", "module."])
+def test_invalid_pep517_backend_references(example):
+    assert formats.pep517_backend_reference(example) is False
+
+
+@pytest.mark.parametrize("example", ["module", "package.module:object.attr"])
+def test_valid_pep517_backend_references(example):
+    assert formats.pep517_backend_reference(example) is True
+
+
 @pytest.mark.parametrize("example", ["λ", "a", "_"])
 def test_valid_python_identifier(example):
     assert formats.python_identifier(example)
@@ -462,6 +478,9 @@ def test_import_name():
     assert formats.import_name("some1; private")
     assert formats.import_name("other.thing ; private")
     assert formats.import_name("_other._thing ; private")
+
+    assert formats.import_name("x")
+    assert formats.import_name("x.y")
 
     assert not formats.import_name("one two")
     assert not formats.import_name("one; two")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses findings 1–3 of #317. Each of these was verified empirically before fixing.

## Fixes

### 1. `import_name` rejects single-character identifiers
The `VALID_IMPORT_NAME` regex required the first identifier segment to be 2+ characters (`[A-Za-z_][A-Za-z_0-9]+`).
- **Before:** `import_name("x")` and `import_name("x.y")` returned `False`.
- **After:** both return `True` (the `+` is now `*`, matching the subsequent-segment pattern).

### 2. `python_entrypoint_reference` crashes on malformed extras
`"mod:obj["` evaluated `extras_.strip()[-1]` on an empty string, raising `IndexError`.
- **Before:** `python_entrypoint_reference("mod:obj[")` raised `IndexError`.
- **After:** returns `False` (uses `.endswith("]")`, which is safe on empty strings).

### 3. `pep517_backend_reference` too lax
Empty dot-separated segments were silently skipped (the `if i` filter), so malformed references passed.
- **Before:** `""`, `":attr"`, `"module:"`, `"a..b:c"`, `"module."` all returned `True`.
- **After:** all return `False`. The module part must be non-empty with every dot-separated segment a valid Python identifier; if a `:` separator is present, the object part must likewise be non-empty and valid. Still accepts `"module"`, `"flit_core.buildapi"`, `"package.module:object"`, `"package.module:object.attr"`.

### 4. `python_entrypoint_reference("module:")` wrongly valid
The partition separator was discarded, so a trailing colon with an empty object was indistinguishable from no colon. Per the entry-points spec the object reference is required after the `:`.
- **Before:** `python_entrypoint_reference("module:")` returned `True`.
- **After:** returns `False`. The separator is now captured and the object part required when present.

## Notes
A shared `_is_dotted_identifier` helper now backs both entry-point and PEP 517 backend reference validation, since findings 2–4 validate near-identical grammars.

## Tests
Added regression tests in `tests/test_formats.py` covering all of the above. Full suite passes (608 passed); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)