### PR TITLE
fix: assorted correctness cleanups in api, error_reporting, and formats

### DIFF
--- a/src/validate_pyproject/api.py
+++ b/src/validate_pyproject/api.py
@@ -94,7 +94,7 @@ class SchemaRegistry(Mapping[str, Schema]):
         project_table_schema = load(PROJECT_TABLE_SCHEMA)
         self._ensure_compatibility(PROJECT_TABLE_SCHEMA, project_table_schema)
         sid = project_table_schema["$id"]
-        top_level["project"] = {"$ref": sid}
+        top_properties["project"] = {"$ref": sid}
         origin = f"{__name__} - project metadata"
         self._schemas = {sid: ("project", origin, project_table_schema)}
 

--- a/src/validate_pyproject/error_reporting.py
+++ b/src/validate_pyproject/error_reporting.py
@@ -39,7 +39,6 @@ _SKIP_DETAILS = (
 _NEED_DETAILS = {"anyOf", "oneOf", "allOf", "contains", "propertyNames", "not", "items"}
 
 _CAMEL_CASE_SPLITTER = re.compile(r"\W+|([A-Z][^A-Z\W]*)")
-_IDENTIFIER = re.compile(r"^[\w_]+$", re.IGNORECASE)
 
 _TOML_JARGON = {
     "object": "table",
@@ -147,7 +146,7 @@ class _ErrorFormatting:
 
     def _expand_details(self) -> str:
         optional = []
-        definition = self.ex.definition or {}
+        definition = dict(self.ex.definition) if self.ex.definition else {}
         desc_lines = definition.pop("$$description", [])
         desc = definition.pop("description", None) or " ".join(desc_lines)
         if desc:

--- a/src/validate_pyproject/formats.py
+++ b/src/validate_pyproject/formats.py
@@ -19,8 +19,7 @@ from itertools import chain as _chain
 
 if typing.TYPE_CHECKING:
     import builtins
-
-    from typing_extensions import Literal
+    from typing import Literal
 
 _logger = logging.getLogger(__name__)
 

--- a/tests/test_error_reporting.py
+++ b/tests/test_error_reporting.py
@@ -143,3 +143,40 @@ def test_error_reporting(caplog, example):
     assert ex.summary in ex.message
     if debug_info != "**SKIP-TEST**":
         assert debug_info in ex.details
+
+
+def test_definition_not_mutated_after_formatting():
+    """Formatting a ValidationError must not mutate ex.definition (no side-effects)."""
+    schema = {"type": "string", "description": "A descriptive message"}
+    with (
+        pytest.raises(ValidationError) as excinfo,
+        detailed_errors(),
+    ):
+        validate(schema, {"name": 42}, formats=FORMAT_FUNCTIONS)
+    ex = excinfo.value
+    # Trigger formatting (which internally calls _expand_details)
+    _ = ex.details
+    # The original definition on the exception must still contain "description"
+    assert ex.definition is not None
+    assert "description" in ex.definition
+
+
+def test_dollar_dollar_description_not_mutated_after_formatting():
+    """Formatting must not mutate $$description out of ex.definition."""
+    schema = {
+        "properties": {
+            "name": {
+                "type": "string",
+                "$$description": ["Lorem ipsum"],
+            }
+        }
+    }
+    with (
+        pytest.raises(ValidationError) as excinfo,
+        detailed_errors(),
+    ):
+        validate(schema, {"name": 42}, formats=FORMAT_FUNCTIONS)
+    ex = excinfo.value
+    _ = ex.details
+    assert ex.definition is not None
+    assert "$$description" in ex.definition


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses findings 5–6 plus two cleanups from #317.

## Changes

1. **`api.py` – fix schema insertion target (finding 5)**
   `top_level["project"] = {"$ref": sid}` wrote the PEP 621 `$ref` as a
   top-level key in the schema dict (a sibling of `"properties"`), where
   JSON Schema ignores it. The fix is `top_properties["project"] = {"$ref": sid}`,
   inserting it under the actual `properties` map. The validator happened to
   work only because `pyproject_toml.schema.json` hardcodes the identical `$ref`
   under `properties.project`.

2. **`error_reporting.py` – avoid mutating `ex.definition` (finding 6)**
   `_ErrorFormatting._expand_details` called `.pop()` directly on
   `self.ex.definition`, permanently stripping `description` /
   `$$description` from the exception's `definition` attribute that callers
   can inspect. Fixed by shallow-copying the dict before popping:
   `definition = dict(self.ex.definition) if self.ex.definition else {}`.
   Two regression tests are added in `tests/test_error_reporting.py`.

3. **`error_reporting.py` – remove dead `_IDENTIFIER` regex**
   `_IDENTIFIER = re.compile(r"^[\w_]+$", re.IGNORECASE)` is never
   referenced anywhere in `src/` or `tests/`. Deleted.

4. **`formats.py` – use stdlib `typing.Literal` instead of `typing_extensions`**
   `Literal` has been available in the stdlib since Python 3.8; this
   project's minimum is 3.9. Replacing the `typing_extensions` import also
   removes a stray `typing_extensions` reference from the vendored output
   generated by `pre_compile/` (which copies `formats.py` verbatim).

## Test plan

- [x] `uv run pytest tests/test_error_reporting.py tests/test_api.py -p no:randomly -q` — 23 passed
- [x] Full suite `uv run pytest -q -n auto` — 598 passed, 1 skipped, 2 pre-existing classifier network failures unrelated to these changes
- [x] `tox -e typecheck` — mypy clean (no issues in 22 source files)
- [x] `uvx ruff check src tests` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)