### PR TITLE
fix: limit fastjsonschmema on 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,10 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
     "Typing :: Typed",
 ]
-dependencies = ["fastjsonschema>=2.16.2,<=3"]
+dependencies = [
+    "fastjsonschema>=2.16.2,<=3; python_version>='3.10'",
+    "fastjsonschema>=2.16.2,<=3,!=2.22.0; python_version<'3.10'"
+]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
Fix for fjs on < 3.10 currently resolving a version that doesn't support <3.10.

See https://github.com/horejsek/python-fastjsonschema/issues/211.